### PR TITLE
Journées et matchs (issue #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.vite
 *.local
 .DS_Store
 tsconfig.tsbuildinfo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { DivisionsPage } from '@/pages/admin/DivisionsPage'
 import { GroupsPage } from '@/pages/admin/GroupsPage'
 import { TeamsPage } from '@/pages/admin/TeamsPage'
 import { PlayersPage } from '@/pages/admin/PlayersPage'
+import { MatchDaysPage } from '@/pages/admin/MatchDaysPage'
 
 function ProtectedLayout() {
   const { isAuthenticated } = useAuth()
@@ -44,6 +45,7 @@ export default function App() {
             <Route path="groupes" element={<GroupsPage />} />
             <Route path="equipes" element={<TeamsPage />} />
             <Route path="joueurs" element={<PlayersPage />} />
+            <Route path="journees" element={<MatchDaysPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -52,6 +52,9 @@ export function AppShell() {
                 <Link to="/equipes" className={navLinkClass(location.pathname === '/equipes')}>
                   Équipes
                 </Link>
+                <Link to="/journees" className={navLinkClass(location.pathname === '/journees')}>
+                  Journées
+                </Link>
               </>
             )}
             {isClubAdmin && !isGeneralAdmin && (

--- a/src/contexts/MockDataContext.tsx
+++ b/src/contexts/MockDataContext.tsx
@@ -14,8 +14,10 @@ import {
   mockGroups as initialGroups,
   mockTeams as initialTeams,
   mockPlayers as initialPlayers,
+  mockMatchDays as initialMatchDays,
+  mockGames as initialGames,
 } from '@/mock/data'
-import type { Club, Season, Phase, Group, Team, Player } from '@/types'
+import type { Club, Season, Phase, Group, Team, Player, MatchDay, Game } from '@/types'
 
 interface MockDataState {
   divisions: Division[]
@@ -25,6 +27,8 @@ interface MockDataState {
   groups: Group[]
   teams: Team[]
   players: Player[]
+  matchDays: MatchDay[]
+  games: Game[]
 }
 
 function nextId(prefix: string): string {
@@ -48,6 +52,12 @@ interface MockDataContextValue extends MockDataState {
   moveDivisionDown: (divisionId: string) => void
   updatePlayer: (id: string, patch: Partial<Player>) => void
   addPlayer: (data: Omit<Player, 'id'>) => Player
+  matchDays: MatchDay[]
+  games: Game[]
+  updateMatchDay: (id: string, patch: Partial<MatchDay>) => void
+  addMatchDay: (data: Omit<MatchDay, 'id'>) => MatchDay
+  updateGame: (id: string, patch: Partial<Game>) => void
+  addGame: (data: Omit<Game, 'id'>) => Game
 }
 
 const MockDataContext = createContext<MockDataContextValue | null>(null)
@@ -60,6 +70,8 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
   const [groups, setGroups] = useState<Group[]>(initialGroups)
   const [teams, setTeams] = useState<Team[]>(initialTeams)
   const [players, setPlayers] = useState<Player[]>(initialPlayers)
+  const [matchDays, setMatchDays] = useState<MatchDay[]>(initialMatchDays)
+  const [games, setGames] = useState<Game[]>(initialGames)
 
   const updateDivision = useCallback((id: string, patch: Partial<Division>) => {
     setDivisions((prev) =>
@@ -180,6 +192,32 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
     return player
   }, [])
 
+  const updateMatchDay = useCallback((id: string, patch: Partial<MatchDay>) => {
+    setMatchDays((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, ...patch } : m))
+    )
+  }, [])
+
+  const addMatchDay = useCallback((data: Omit<MatchDay, 'id'>) => {
+    const id = nextId('md')
+    const matchDay: MatchDay = { ...data, id }
+    setMatchDays((prev) => [...prev, matchDay])
+    return matchDay
+  }, [])
+
+  const updateGame = useCallback((id: string, patch: Partial<Game>) => {
+    setGames((prev) =>
+      prev.map((g) => (g.id === id ? { ...g, ...patch } : g))
+    )
+  }, [])
+
+  const addGame = useCallback((data: Omit<Game, 'id'>) => {
+    const id = nextId('game')
+    const game: Game = { ...data, id }
+    setGames((prev) => [...prev, game])
+    return game
+  }, [])
+
   const value = useMemo<MockDataContextValue>(
     () => ({
       divisions,
@@ -189,6 +227,8 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       groups,
       teams,
       players,
+      matchDays,
+      games,
       updateDivision,
       updateClub,
       updateSeason,
@@ -205,6 +245,10 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       moveDivisionDown,
       updatePlayer,
       addPlayer,
+      updateMatchDay,
+      addMatchDay,
+      updateGame,
+      addGame,
     }),
     [
       divisions,
@@ -214,6 +258,8 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       groups,
       teams,
       players,
+      matchDays,
+      games,
       updateDivision,
       updateClub,
       updateSeason,
@@ -230,6 +276,10 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       moveDivisionDown,
       updatePlayer,
       addPlayer,
+      updateMatchDay,
+      addMatchDay,
+      updateGame,
+      addGame,
     ]
   )
 

--- a/src/lib/roundRobin.ts
+++ b/src/lib/roundRobin.ts
@@ -1,0 +1,49 @@
+/**
+ * Round-robin tournament: each team plays each other once.
+ * Returns an array of rounds; each round is an array of { home, away } pairs.
+ * For n teams: n-1 rounds if n even, n rounds if n odd (one bye per round when odd).
+ * Spec: 7 or 8 teams → 7 match-days, 6 teams → 5 match-days.
+ */
+export function roundRobin<T>(teams: T[]): { home: T; away: T }[][] {
+  const n = teams.length
+  if (n < 2) return []
+
+  const numRounds = n % 2 === 0 ? n - 1 : n
+  const size = n % 2 === 0 ? n : n + 1
+  const rotating = size - 1
+
+  const indices: (T | null)[] = n % 2 === 0 ? [...teams] : [...teams, null]
+
+  const rounds: { home: T; away: T }[][] = []
+  for (let r = 0; r < numRounds; r++) {
+    const round: { home: T; away: T }[] = []
+    // Fixed team at index 0 plays the one at circle position (rotating - r)
+    const oppPos = (rotating - r + rotating) % rotating
+    const secondIdx = oppPos === 0 ? rotating : oppPos
+    const first = indices[0]
+    const second = indices[secondIdx]
+    if (first != null && second != null) round.push({ home: first, away: second })
+
+    // Other pairs: circle positions 1..n-1 (1-based); 0 mod (n-1) means position n-1
+    for (let i = 1; i < size / 2; i++) {
+      const posA = (r + i) % rotating
+      const posB = (r + rotating - i) % rotating
+      const idxA = posA === 0 ? rotating : posA
+      const idxB = posB === 0 ? rotating : posB
+      const teamA = indices[idxA]
+      const teamB = indices[idxB]
+      if (teamA != null && teamB != null) round.push({ home: teamA, away: teamB })
+    }
+    rounds.push(round)
+  }
+
+  return rounds
+}
+
+/**
+ * Number of match-days for a group of given size (Spec: 8→7, 7→7, 6→5).
+ */
+export function matchDayCountForGroupSize(n: number): number {
+  if (n < 2) return 0
+  return n % 2 === 0 ? n - 1 : n
+}

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -76,8 +76,8 @@ export const mockTeams: Team[] = [
 ]
 
 export const mockMatchDays: MatchDay[] = [
-  { id: 'md-1', phaseId: 'phase-1', number: 1, date: '2025-10-02' },
-  { id: 'md-2', phaseId: 'phase-1', number: 2, date: '2025-10-09' },
+  { id: 'md-1', groupId: 'group-1', number: 1, date: '2025-10-02' },
+  { id: 'md-2', groupId: 'group-1', number: 2, date: '2025-10-09' },
 ]
 
 export const mockGames: Game[] = [

--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -1,0 +1,463 @@
+import { useState, useMemo } from 'react'
+import type { MatchDay, Game } from '@/types'
+import { useMockData } from '@/contexts/MockDataContext'
+
+export function MatchDaysPage() {
+  const {
+    phases,
+    divisions,
+    groups,
+    matchDays,
+    games,
+    teams,
+    clubs,
+    addMatchDay,
+    updateMatchDay,
+    addGame,
+    updateGame,
+  } = useMockData()
+  const [selectedPhaseId, setSelectedPhaseId] = useState<string>(phases[0]?.id ?? '')
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('')
+
+  const phaseGroups = useMemo(() => {
+    return groups.filter((g) => {
+      const div = divisions.find((d) => d.id === g.divisionId)
+      return div?.phaseId === selectedPhaseId
+    })
+  }, [groups, divisions, selectedPhaseId])
+
+  const effectiveGroupId = selectedGroupId || phaseGroups[0]?.id || ''
+  const groupMatchDays = matchDays
+    .filter((m) => m.groupId === effectiveGroupId)
+    .sort((a, b) => a.number - b.number)
+  const hasMatchDays = groupMatchDays.length > 0
+
+  const [editingMatchDay, setEditingMatchDay] = useState<MatchDay | null>(null)
+  const [creatingMatchDay, setCreatingMatchDay] = useState(false)
+  const [matchDayForm, setMatchDayForm] = useState({ groupId: '', number: 1, date: '' })
+
+  const [addingGameForMatchDayId, setAddingGameForMatchDayId] = useState<string | null>(null)
+  const [editingGame, setEditingGame] = useState<Game | null>(null)
+  const [gameForm, setGameForm] = useState({ homeTeamId: '', awayTeamId: '' })
+
+  const getTeamLabel = (teamId: string) => {
+    const team = teams.find((t) => t.id === teamId)
+    if (!team) return teamId
+    const club = clubs.find((c) => c.id === team.clubId)
+    return `${club?.displayName ?? team.clubId} ${team.number}`
+  }
+
+  const getGroupLabel = (groupId: string) => {
+    const g = groups.find((x) => x.id === groupId)
+    if (!g) return groupId
+    const div = divisions.find((d) => d.id === g.divisionId)
+    return div ? `${div.displayName} – Groupe ${g.number}` : `Groupe ${g.number}`
+  }
+
+  const nextMatchDayNumber = () => {
+    if (!effectiveGroupId) return 1
+    const inGroup = matchDays.filter((m) => m.groupId === effectiveGroupId)
+    if (inGroup.length === 0) return 1
+    return Math.max(...inGroup.map((m) => m.number)) + 1
+  }
+
+  const openCreateMatchDay = () => {
+    setCreatingMatchDay(true)
+    setEditingMatchDay(null)
+    const today = new Date().toISOString().slice(0, 10)
+    setMatchDayForm({
+      groupId: effectiveGroupId,
+      number: nextMatchDayNumber(),
+      date: today,
+    })
+  }
+
+  const openEditMatchDay = (md: MatchDay) => {
+    setEditingMatchDay(md)
+    setCreatingMatchDay(false)
+    setMatchDayForm({
+      groupId: md.groupId,
+      number: md.number,
+      date: md.date,
+    })
+  }
+
+  const closeMatchDayModal = () => {
+    setEditingMatchDay(null)
+    setCreatingMatchDay(false)
+  }
+
+  const handleSaveMatchDay = () => {
+    if (creatingMatchDay && matchDayForm.groupId && matchDayForm.date) {
+      addMatchDay({
+        groupId: matchDayForm.groupId,
+        number: matchDayForm.number,
+        date: matchDayForm.date,
+      })
+      closeMatchDayModal()
+    } else if (editingMatchDay) {
+      updateMatchDay(editingMatchDay.id, {
+        number: matchDayForm.number,
+        date: matchDayForm.date,
+      })
+      closeMatchDayModal()
+    }
+  }
+
+  const openAddGame = (matchDayId: string) => {
+    setAddingGameForMatchDayId(matchDayId)
+    setEditingGame(null)
+    setGameForm({ homeTeamId: '', awayTeamId: '' })
+  }
+
+  const openEditGame = (game: Game) => {
+    setEditingGame(game)
+    setAddingGameForMatchDayId(null)
+    setGameForm({ homeTeamId: game.homeTeamId, awayTeamId: game.awayTeamId })
+  }
+
+  const closeGameModal = () => {
+    setAddingGameForMatchDayId(null)
+    setEditingGame(null)
+  }
+
+  const handleSaveGame = () => {
+    if (addingGameForMatchDayId && gameForm.homeTeamId && gameForm.awayTeamId) {
+      addGame({
+        matchDayId: addingGameForMatchDayId,
+        homeTeamId: gameForm.homeTeamId,
+        awayTeamId: gameForm.awayTeamId,
+      })
+      closeGameModal()
+    } else if (editingGame) {
+      updateGame(editingGame.id, {
+        homeTeamId: gameForm.homeTeamId,
+        awayTeamId: gameForm.awayTeamId,
+      })
+      closeGameModal()
+    }
+  }
+
+  const gameModalMatchDayId = addingGameForMatchDayId ?? editingGame?.matchDayId ?? null
+  const gameModalMatchDay = gameModalMatchDayId
+    ? matchDays.find((m) => m.id === gameModalMatchDayId)
+    : null
+  const gameModalGroup = gameModalMatchDay
+    ? groups.find((g) => g.id === gameModalMatchDay.groupId)
+    : null
+  const gameModalTeams = useMemo(() => {
+    if (!gameModalGroup) return []
+    return teams.filter((t) => gameModalGroup.teamIds.includes(t.id))
+  }, [teams, gameModalGroup])
+
+  const gameModalUsedTeamIds = useMemo(() => {
+    if (!gameModalMatchDayId) return new Set<string>()
+    const dayGames = games.filter((g) => g.matchDayId === gameModalMatchDayId)
+    const toExclude =
+      editingGame && dayGames.some((g) => g.id === editingGame.id)
+        ? dayGames.filter((g) => g.id !== editingGame.id)
+        : dayGames
+    return new Set(toExclude.flatMap((g) => [g.homeTeamId, g.awayTeamId]))
+  }, [games, gameModalMatchDayId, editingGame?.id])
+
+  const gameModalAvailableTeams = useMemo(
+    () => gameModalTeams.filter((t) => !gameModalUsedTeamIds.has(t.id)),
+    [gameModalTeams, gameModalUsedTeamIds]
+  )
+
+  const homeTeamOptions = useMemo(
+    () => gameModalAvailableTeams.filter((t) => t.id !== gameForm.awayTeamId),
+    [gameModalAvailableTeams, gameForm.awayTeamId]
+  )
+  const awayTeamOptions = useMemo(
+    () => gameModalAvailableTeams.filter((t) => t.id !== gameForm.homeTeamId),
+    [gameModalAvailableTeams, gameForm.homeTeamId]
+  )
+
+  const handlePhaseChange = (phaseId: string) => {
+    setSelectedPhaseId(phaseId)
+    const nextGroups = groups.filter((g) => {
+      const div = divisions.find((d) => d.id === g.divisionId)
+      return div?.phaseId === phaseId
+    })
+    setSelectedGroupId(nextGroups[0]?.id ?? '')
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-semibold text-slate-800">
+            Journées et matchs
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Définir les journées et les matchs par groupe.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={selectedPhaseId}
+            onChange={(e) => handlePhaseChange(e.target.value)}
+            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+          >
+            {phases.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.displayName}
+              </option>
+            ))}
+          </select>
+          {phaseGroups.length > 0 && (
+            <select
+              value={effectiveGroupId}
+              onChange={(e) => setSelectedGroupId(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+            >
+              {phaseGroups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {getGroupLabel(g.id)}
+                </option>
+              ))}
+            </select>
+          )}
+          <button
+            type="button"
+            onClick={openCreateMatchDay}
+            disabled={!effectiveGroupId}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            Ajouter une journée
+          </button>
+        </div>
+      </div>
+
+      {selectedPhaseId && phaseGroups.length === 0 && (
+        <p className="text-sm text-slate-600">Aucun groupe dans cette phase.</p>
+      )}
+
+      {selectedPhaseId && phaseGroups.length > 0 && !effectiveGroupId && (
+        <p className="text-sm text-slate-600">Sélectionnez un groupe.</p>
+      )}
+
+      {effectiveGroupId && !hasMatchDays && (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-6 text-center">
+          <p className="text-slate-600">
+            Aucune journée pour ce groupe. Cliquez sur « Ajouter une journée » pour en créer une.
+          </p>
+        </div>
+      )}
+
+      {effectiveGroupId && hasMatchDays && (
+        <div className="space-y-6">
+          {groupMatchDays.map((md) => {
+            const dayGames = games.filter((g) => g.matchDayId === md.id)
+            return (
+              <section
+                key={md.id}
+                className="overflow-hidden rounded-xl border border-slate-200 bg-white"
+              >
+                <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-4 py-3">
+                  <h2 className="font-display text-lg font-medium text-slate-800">
+                    Journée {md.number}
+                    <span className="ml-2 text-sm font-normal text-slate-600">
+                      {new Date(md.date + 'Z').toLocaleDateString('fr-FR', {
+                        weekday: 'long',
+                        day: 'numeric',
+                        month: 'long',
+                        year: 'numeric',
+                      })}
+                    </span>
+                  </h2>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => openEditMatchDay(md)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openAddGame(md.id)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Ajouter un match
+                    </button>
+                  </div>
+                </div>
+                <ul className="divide-y divide-slate-200">
+                  {dayGames.length === 0 ? (
+                    <li className="px-4 py-3 text-sm text-slate-500">Aucun match</li>
+                  ) : (
+                    dayGames.map((game) => (
+                      <li
+                        key={game.id}
+                        className="flex items-center justify-between px-4 py-3 hover:bg-slate-50/50"
+                      >
+                        <span className="text-sm font-medium text-slate-900">
+                          {getTeamLabel(game.homeTeamId)}
+                        </span>
+                        <span className="text-sm text-slate-400">—</span>
+                        <span className="text-sm font-medium text-slate-900">
+                          {getTeamLabel(game.awayTeamId)}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => openEditGame(game)}
+                          className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                        >
+                          Modifier
+                        </button>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </section>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Create / Edit match-day modal */}
+      {(editingMatchDay || creatingMatchDay) && (
+        <div
+          className="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="matchday-modal-title"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
+            <h2 id="matchday-modal-title" className="font-display text-lg font-semibold text-slate-800">
+              {creatingMatchDay ? 'Ajouter une journée' : 'Modifier la journée'}
+            </h2>
+            <div className="mt-4 space-y-4">
+              {creatingMatchDay && effectiveGroupId && (
+                <div>
+                  <span className="block text-sm font-medium text-slate-700">Groupe</span>
+                  <p className="mt-1 text-sm text-slate-900">{getGroupLabel(effectiveGroupId)}</p>
+                </div>
+              )}
+              <div>
+                <label htmlFor="md-number" className="block text-sm font-medium text-slate-700">
+                  Numéro de journée
+                </label>
+                <input
+                  id="md-number"
+                  type="number"
+                  min={1}
+                  value={matchDayForm.number}
+                  onChange={(e) =>
+                    setMatchDayForm((f) => ({ ...f, number: Number(e.target.value) || 1 }))
+                  }
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                />
+              </div>
+              <div>
+                <label htmlFor="md-date" className="block text-sm font-medium text-slate-700">
+                  Date
+                </label>
+                <input
+                  id="md-date"
+                  type="date"
+                  value={matchDayForm.date}
+                  onChange={(e) => setMatchDayForm((f) => ({ ...f, date: e.target.value }))}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                />
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeMatchDayModal}
+                className="rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveMatchDay}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Enregistrer
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Add / Edit game modal — teams restricted to the match-day's group */}
+      {(addingGameForMatchDayId || editingGame) && (
+        <div
+          className="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="game-modal-title"
+        >
+          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
+            <h2 id="game-modal-title" className="font-display text-lg font-semibold text-slate-800">
+              {editingGame ? 'Modifier le match' : 'Ajouter un match'}
+            </h2>
+            <div className="mt-4 space-y-4">
+              <div>
+                <label htmlFor="game-home" className="block text-sm font-medium text-slate-700">
+                  Équipe à domicile
+                </label>
+                <select
+                  id="game-home"
+                  value={gameForm.homeTeamId}
+                  onChange={(e) => setGameForm((f) => ({ ...f, homeTeamId: e.target.value }))}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                >
+                  <option value="">—</option>
+                  {homeTeamOptions.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {getTeamLabel(t.id)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="game-away" className="block text-sm font-medium text-slate-700">
+                  Équipe extérieur
+                </label>
+                <select
+                  id="game-away"
+                  value={gameForm.awayTeamId}
+                  onChange={(e) => setGameForm((f) => ({ ...f, awayTeamId: e.target.value }))}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                >
+                  <option value="">—</option>
+                  {awayTeamOptions.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {getTeamLabel(t.id)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeGameModal}
+                className="rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveGame}
+                disabled={
+                  !gameForm.homeTeamId ||
+                  !gameForm.awayTeamId ||
+                  gameForm.homeTeamId === gameForm.awayTeamId
+                }
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                Enregistrer
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,7 +78,7 @@ export interface Team {
 
 export interface MatchDay {
   id: string
-  phaseId: string
+  groupId: string
   number: number
   date: string
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, 'src'),
     },
   },
 })


### PR DESCRIPTION
## Match-days and games (issue #4)

- **Match-days in group context**: Phase → group selector; match-days are created and listed per group.
- **Manual definition**: No generation; create/edit match-days (number, date) and add/edit games (home/away) manually.
- **Teams per group only**: When adding/editing a game, only teams of that group can be selected.
- **No duplicate team per match-day**: On a given match-day, a team can only appear in one game; dropdowns exclude teams already playing that day.

Also includes:
- Vite `@/` alias fix for ESM
- Journées route and nav link
- `.vite` in .gitignore

Closes #4

Made with [Cursor](https://cursor.com)