### PR TITLE
Game availability and captain/player experience (issue #5)

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -6,21 +6,23 @@ This doc maps the SPEC to a phased plan. Each row links to a GitHub issue; use o
 
 ## Phases and issues
 
-| # | Description | Status |
-|---|-------------|--------|
-| [**#2**](https://github.com/gknobloch/ping-pong-club/issues/2) | **Initial app (Phase 0+)** — Vite + React + TypeScript + Tailwind, French UI, dev login (user autocomplete, no password), mock data. General Admin: CRUD for clubs, seasons, phases, divisions, groups, teams; division reorder. Club Admin: club context in header and home, teams filtered by club, Joueurs page (list/add/edit players). | Done |
-| [**#4**](https://github.com/gknobloch/ping-pong-club/issues/4) | **Match-days and games** — Match-days per group (phase → group → journées). Manual create/edit match-days (number, date) and games (home/away). Teams restricted to group; no duplicate team per match-day. Journées page with list/view. | Done |
-| [**#5**](https://github.com/gknobloch/ping-pong-club/issues/5) | **Game availability** — Per game, each player of the team can set availability. Captain (and Club Admin) can override. Enforce “one player per team per match-day” in UI/API. | To do |
-| [**#6**](https://github.com/gknobloch/ping-pong-club/issues/6) | **Captain: game selection** — For each game, captain picks which players actually play (from team roster; later: from club active players with rules). Default list from team. | To do |
-| [**#7**](https://github.com/gknobloch/ping-pong-club/issues/7) | **Persist data (replace mock)** — Replace in-memory mock with real storage (e.g. D1 or KV on Cloudflare; or SQLite locally then D1). Expose same operations via API or context. | To do |
-| [**#8**](https://github.com/gknobloch/ping-pong-club/issues/8) | **Auth (replace dev login)** — Replace “login as any user” with real auth (e.g. Cloudflare Access, or OAuth / magic link). Store user/club/role in DB. | To do |
-| [**#9**](https://github.com/gknobloch/ping-pong-club/issues/9) | **Deploy to Cloudflare** — Frontend on Pages (or Workers); API on Workers; D1/KV bound. Env config for prod. | To do |
-| [**#10**](https://github.com/gknobloch/ping-pong-club/issues/10) | **Player–team assignment and points** — Per phase: assign player to at most one team; set “locked” points for the phase. Club Admin: define team roster and initial points. | To do |
-| [**#11**](https://github.com/gknobloch/ping-pong-club/issues/11) | **Club addresses CRUD** — Add/edit/delete addresses for a club; set default address. Used for team game location. | To do |
-| [**#12**](https://github.com/gknobloch/ping-pong-club/issues/12) | **Rules for player eligibility** — Rules determining if a player is allowed to play in a certain team. Defer to later; optional. | To do |
-| [**#13**](https://github.com/gknobloch/ping-pong-club/issues/13) | **UX and i18n pass** — Consistent French copy, mobile-friendly layout, accessibility. Optional/polish. | To do |
-| [**#14**](https://github.com/gknobloch/ping-pong-club/issues/14) | **Delete for entities** — Add “Supprimer” (and confirmation) for clubs, seasons, phases, divisions, groups, teams, players where spec allows. Optional/polish. | To do |
-| [**#15**](https://github.com/gknobloch/ping-pong-club/issues/15) | **Copy divisions from previous phase** — When creating a new phase, “copy from previous phase” for divisions (and optionally groups). Optional/polish. | To do |
+Status of each item can be seen from the linked GitHub issue.
+
+| # | Description |
+|---|-------------|
+| [**#2**](https://github.com/gknobloch/ping-pong-club/issues/2) | **Initial app (Phase 0+)** — Vite + React + TypeScript + Tailwind, French UI, dev login (user autocomplete, no password), mock data. General Admin: CRUD for clubs, seasons, phases, divisions, groups, teams; division reorder. Club Admin: club context in header and home, teams filtered by club, Joueurs page (list/add/edit players). |
+| [**#4**](https://github.com/gknobloch/ping-pong-club/issues/4) | **Match-days and games** — Match-days per group (phase → group → journées). Manual create/edit match-days (number, date) and games (home/away). Teams restricted to group; no duplicate team per match-day. Journées page with list/view. |
+| [**#5**](https://github.com/gknobloch/ping-pong-club/issues/5) | **Game availability** — Per game, each player of the team can set availability. Captain (and Club Admin) can override. Enforce “one player per team per match-day” in UI/API. Captain/Player nav and club-scoped data; availability 3 states; opponent roster hidden. |
+| [**#6**](https://github.com/gknobloch/ping-pong-club/issues/6) | **Captain: game selection** — For each game, captain picks which players actually play (from team roster; later: from club active players with rules). Default list from team. |
+| [**#7**](https://github.com/gknobloch/ping-pong-club/issues/7) | **Persist data (replace mock)** — Replace in-memory mock with real storage (e.g. D1 or KV on Cloudflare; or SQLite locally then D1). Expose same operations via API or context. |
+| [**#8**](https://github.com/gknobloch/ping-pong-club/issues/8) | **Auth (replace dev login)** — Replace “login as any user” with real auth (e.g. Cloudflare Access, or OAuth / magic link). Store user/club/role in DB. |
+| [**#9**](https://github.com/gknobloch/ping-pong-club/issues/9) | **Deploy to Cloudflare** — Frontend on Pages (or Workers); API on Workers; D1/KV bound. Env config for prod. |
+| [**#10**](https://github.com/gknobloch/ping-pong-club/issues/10) | **Player–team assignment and points** — Per phase: assign player to at most one team; set “locked” points for the phase. Club Admin: define team roster and initial points. |
+| [**#11**](https://github.com/gknobloch/ping-pong-club/issues/11) | **Club addresses CRUD** — Add/edit/delete addresses for a club; set default address. Used for team game location. |
+| [**#12**](https://github.com/gknobloch/ping-pong-club/issues/12) | **Rules for player eligibility** — Rules determining if a player is allowed to play in a certain team. Defer to later; optional. |
+| [**#13**](https://github.com/gknobloch/ping-pong-club/issues/13) | **UX and i18n pass** — Consistent French copy, mobile-friendly layout, accessibility. Optional/polish. |
+| [**#14**](https://github.com/gknobloch/ping-pong-club/issues/14) | **Delete for entities** — Add “Supprimer” (and confirmation) for clubs, seasons, phases, divisions, groups, teams, players where spec allows. Optional/polish. |
+| [**#15**](https://github.com/gknobloch/ping-pong-club/issues/15) | **Copy divisions from previous phase** — When creating a new phase, “copy from previous phase” for divisions (and optionally groups). Optional/polish. |
 
 ---
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -57,10 +57,13 @@ export function AppShell() {
                 </Link>
               </>
             )}
-            {isClubAdmin && !isGeneralAdmin && (
+            {(isClubAdmin || user?.role === 'captain' || user?.role === 'player') && !isGeneralAdmin && (
               <>
                 <Link to="/equipes" className={navLinkClass(location.pathname === '/equipes')}>
                   Équipes
+                </Link>
+                <Link to="/journees" className={navLinkClass(location.pathname === '/journees')}>
+                  Journées
                 </Link>
                 <Link to="/joueurs" className={navLinkClass(location.pathname === '/joueurs')}>
                   Joueurs
@@ -74,7 +77,7 @@ export function AppShell() {
             )}
             <div className="flex items-center gap-3 border-l border-slate-200 pl-4">
               <div className="text-right hidden sm:block">
-                {isClubAdmin && !isGeneralAdmin && adminClubNames && (
+                {(isClubAdmin || user?.role === 'captain' || user?.role === 'player') && !isGeneralAdmin && adminClubNames && (
                   <p className="text-xs font-medium text-slate-600">Club : {adminClubNames}</p>
                 )}
                 <p className="text-sm font-medium text-slate-800">{displayName}</p>

--- a/src/contexts/MockDataContext.tsx
+++ b/src/contexts/MockDataContext.tsx
@@ -16,8 +16,21 @@ import {
   mockPlayers as initialPlayers,
   mockMatchDays as initialMatchDays,
   mockGames as initialGames,
+  mockGameAvailabilities as initialGameAvailabilities,
 } from '@/mock/data'
-import type { Club, Season, Phase, Group, Team, Player, MatchDay, Game } from '@/types'
+import type {
+  Club,
+  Season,
+  Phase,
+  Group,
+  Team,
+  Player,
+  MatchDay,
+  Game,
+  GameAvailability,
+  AvailabilityStatus,
+  AvailabilityOverriddenBy,
+} from '@/types'
 
 interface MockDataState {
   divisions: Division[]
@@ -29,6 +42,7 @@ interface MockDataState {
   players: Player[]
   matchDays: MatchDay[]
   games: Game[]
+  gameAvailabilities: GameAvailability[]
 }
 
 function nextId(prefix: string): string {
@@ -58,6 +72,14 @@ interface MockDataContextValue extends MockDataState {
   addMatchDay: (data: Omit<MatchDay, 'id'>) => MatchDay
   updateGame: (id: string, patch: Partial<Game>) => void
   addGame: (data: Omit<Game, 'id'>) => Game
+  gameAvailabilities: GameAvailability[]
+  setGameAvailability: (
+    gameId: string,
+    playerId: string,
+    status: AvailabilityStatus,
+    overriddenBy?: AvailabilityOverriddenBy
+  ) => void
+  clearGameAvailability: (gameId: string, playerId: string) => void
 }
 
 const MockDataContext = createContext<MockDataContextValue | null>(null)
@@ -72,6 +94,9 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
   const [players, setPlayers] = useState<Player[]>(initialPlayers)
   const [matchDays, setMatchDays] = useState<MatchDay[]>(initialMatchDays)
   const [games, setGames] = useState<Game[]>(initialGames)
+  const [gameAvailabilities, setGameAvailabilities] = useState<GameAvailability[]>(
+    initialGameAvailabilities
+  )
 
   const updateDivision = useCallback((id: string, patch: Partial<Division>) => {
     setDivisions((prev) =>
@@ -218,6 +243,39 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
     return game
   }, [])
 
+  const setGameAvailability = useCallback(
+    (
+      gameId: string,
+      playerId: string,
+      status: AvailabilityStatus,
+      overriddenBy?: AvailabilityOverriddenBy
+    ) => {
+      setGameAvailabilities((prev) => {
+        const existing = prev.find(
+          (a) => a.gameId === gameId && a.playerId === playerId
+        )
+        if (existing) {
+          return prev.map((a) =>
+            a.id === existing.id
+              ? { ...a, status, overriddenBy }
+              : a
+          )
+        }
+        return [
+          ...prev,
+          { id: nextId('avail'), gameId, playerId, status, overriddenBy },
+        ]
+      })
+    },
+    []
+  )
+
+  const clearGameAvailability = useCallback((gameId: string, playerId: string) => {
+    setGameAvailabilities((prev) =>
+      prev.filter((a) => !(a.gameId === gameId && a.playerId === playerId))
+    )
+  }, [])
+
   const value = useMemo<MockDataContextValue>(
     () => ({
       divisions,
@@ -249,6 +307,9 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       addMatchDay,
       updateGame,
       addGame,
+      gameAvailabilities,
+      setGameAvailability,
+      clearGameAvailability,
     }),
     [
       divisions,
@@ -280,6 +341,9 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       addMatchDay,
       updateGame,
       addGame,
+      gameAvailabilities,
+      setGameAvailability,
+      clearGameAvailability,
     ]
   )
 

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -1,4 +1,4 @@
-import type { User, Club, Season, Phase, Division, Group, Team, Player, Address, MatchDay, Game } from '@/types'
+import type { User, Club, Season, Phase, Division, Group, Team, Player, Address, MatchDay, Game, GameAvailability } from '@/types'
 
 const addresses: Address[] = [
   { id: 'addr-1', label: 'Gymnase principal', street: '12 rue du Sport', postalCode: '68170', city: 'Rixheim', isDefault: true },
@@ -40,7 +40,7 @@ export const mockPlayers: Player[] = [
   { id: 'player-2', firstName: 'Jean', lastName: 'Martin', licenseNumber: '6814427', email: 'jean.martin@example.com', phone: '06 23 45 67 89', status: 'active', clubId: 'club-1' },
   { id: 'player-3', firstName: 'Sophie', lastName: 'Bernard', licenseNumber: '6814428', email: 'sophie.bernard@example.com', phone: '06 34 56 78 90', status: 'active', clubId: 'club-1' },
   { id: 'player-4', firstName: 'Pierre', lastName: 'Leroy', licenseNumber: '6814429', email: 'pierre.leroy@example.com', phone: '06 45 67 89 01', status: 'active', clubId: 'club-1' },
-  { id: 'player-5', firstName: 'Admin', lastName: 'Global', licenseNumber: '0000001', email: 'admin@example.com', phone: '', status: 'active', clubId: 'club-1' },
+  { id: 'player-5', firstName: 'Admin', lastName: 'Global', licenseNumber: '0000001', email: 'admin@example.com', phone: '', status: 'active', clubId: '' },
   { id: 'player-6', firstName: 'Claire', lastName: 'Admin', licenseNumber: '0000002', email: 'club.admin@example.com', phone: '', status: 'active', clubId: 'club-1' },
 ]
 
@@ -60,6 +60,7 @@ export const mockTeams: Team[] = [
     defaultDay: 'Jeudi',
     defaultTime: '20h00',
     captainId: 'player-1',
+    playerIds: ['player-1', 'player-3', 'player-4'],
   },
   {
     id: 'team-2',
@@ -72,6 +73,7 @@ export const mockTeams: Team[] = [
     defaultDay: 'Mercredi',
     defaultTime: '19h30',
     captainId: 'player-2',
+    playerIds: ['player-2'],
   },
 ]
 
@@ -84,8 +86,10 @@ export const mockGames: Game[] = [
   { id: 'game-1', matchDayId: 'md-1', homeTeamId: 'team-1', awayTeamId: 'team-2' },
 ]
 
+export const mockGameAvailabilities: GameAvailability[] = []
+
 export const mockUsers: User[] = [
-  { id: 'user-1', email: 'admin@example.com', role: 'general_admin', playerId: 'player-5', clubIds: ['club-1'], captainTeamIds: [] },
+  { id: 'user-1', email: 'admin@example.com', role: 'general_admin', playerId: 'player-5', clubIds: [], captainTeamIds: [] },
   { id: 'user-2', email: 'club.admin@example.com', role: 'club_admin', playerId: 'player-6', clubIds: ['club-1'], captainTeamIds: [] },
   { id: 'user-3', email: 'marie.dupont@example.com', role: 'captain', playerId: 'player-1', clubIds: ['club-1'], captainTeamIds: ['team-1'] },
   { id: 'user-4', email: 'jean.martin@example.com', role: 'player', playerId: 'player-2', clubIds: ['club-1'], captainTeamIds: [] },

--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -1,8 +1,10 @@
 import { useState, useMemo } from 'react'
-import type { MatchDay, Game } from '@/types'
+import type { MatchDay, Game, AvailabilityStatus, Player } from '@/types'
+import { useAuth } from '@/contexts/AuthContext'
 import { useMockData } from '@/contexts/MockDataContext'
 
 export function MatchDaysPage() {
+  const { user } = useAuth()
   const {
     phases,
     divisions,
@@ -11,6 +13,10 @@ export function MatchDaysPage() {
     games,
     teams,
     clubs,
+    players,
+    gameAvailabilities,
+    setGameAvailability,
+    clearGameAvailability,
     addMatchDay,
     updateMatchDay,
     addGame,
@@ -39,6 +45,7 @@ export function MatchDaysPage() {
   const [addingGameForMatchDayId, setAddingGameForMatchDayId] = useState<string | null>(null)
   const [editingGame, setEditingGame] = useState<Game | null>(null)
   const [gameForm, setGameForm] = useState({ homeTeamId: '', awayTeamId: '' })
+  const [availabilityModalGame, setAvailabilityModalGame] = useState<Game | null>(null)
 
   const getTeamLabel = (teamId: string) => {
     const team = teams.find((t) => t.id === teamId)
@@ -52,6 +59,52 @@ export function MatchDaysPage() {
     if (!g) return groupId
     const div = divisions.find((d) => d.id === g.divisionId)
     return div ? `${div.displayName} – Groupe ${g.number}` : `Groupe ${g.number}`
+  }
+
+  const getAvailability = (gameId: string, playerId: string): AvailabilityStatus | undefined => {
+    const a = gameAvailabilities.find((x) => x.gameId === gameId && x.playerId === playerId)
+    return a?.status
+  }
+
+  /** Can view availability for this game (member of home or away club). Edit is separate. */
+  const canViewGameAvailability = (game: Game): boolean => {
+    if (!user?.clubIds?.length) return false
+    const homeTeam = teams.find((t) => t.id === game.homeTeamId)
+    const awayTeam = teams.find((t) => t.id === game.awayTeamId)
+    if (!homeTeam || !awayTeam) return false
+    return user.clubIds.includes(homeTeam.clubId) || user.clubIds.includes(awayTeam.clubId)
+  }
+
+  /** Only player (self), captain (their team), or club_admin (their club). Global admin has no edit. */
+  const canEditAvailability = (playerId: string, teamId: string): boolean => {
+    if (!user) return false
+    const team = teams.find((t) => t.id === teamId)
+    if (!team) return false
+    const isOwn = user.playerId === playerId
+    const isCaptain = user.captainTeamIds.includes(teamId)
+    const isClubAdminForTeam = user.role === 'club_admin' && user.clubIds.includes(team.clubId)
+    return isOwn || isCaptain || isClubAdminForTeam
+  }
+
+  const isOverride = (playerId: string, teamId: string): 'captain' | 'club_admin' | undefined => {
+    if (!user) return undefined
+    const team = teams.find((t) => t.id === teamId)
+    if (!team) return undefined
+    if (user.playerId === playerId) return undefined
+    if (user.captainTeamIds.includes(teamId)) return 'captain'
+    if (user.role === 'club_admin' && user.clubIds.includes(team.clubId)) return 'club_admin'
+    return undefined
+  }
+
+  const availabilityLabel: Record<AvailabilityStatus, string> = {
+    available: 'Disponible',
+    maybe: 'Peut-être',
+    unavailable: 'Indisponible',
+  }
+
+  const getPlayerName = (playerId: string) => {
+    const p = players.find((x) => x.id === playerId)
+    return p ? `${p.firstName} ${p.lastName}` : playerId
   }
 
   const nextMatchDayNumber = () => {
@@ -300,13 +353,24 @@ export function MatchDaysPage() {
                         <span className="text-sm font-medium text-slate-900">
                           {getTeamLabel(game.awayTeamId)}
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => openEditGame(game)}
-                          className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                        >
-                          Modifier
-                        </button>
+                        <div className="flex gap-2">
+                          {canViewGameAvailability(game) && (
+                            <button
+                              type="button"
+                              onClick={() => setAvailabilityModalGame(game)}
+                              className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                            >
+                              Disponibilités
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => openEditGame(game)}
+                            className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                          >
+                            Modifier
+                          </button>
+                        </div>
                       </li>
                     ))
                   )}
@@ -454,6 +518,124 @@ export function MatchDaysPage() {
               >
                 Enregistrer
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Availability modal */}
+      {availabilityModalGame && (
+        <div
+          className="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="availability-modal-title"
+        >
+          <div className="w-full max-w-lg rounded-xl bg-white p-6 shadow-lg max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between">
+              <h2 id="availability-modal-title" className="font-display text-lg font-semibold text-slate-800">
+                Disponibilités — {getTeamLabel(availabilityModalGame.homeTeamId)} vs{' '}
+                {getTeamLabel(availabilityModalGame.awayTeamId)}
+              </h2>
+              <button
+                type="button"
+                onClick={() => setAvailabilityModalGame(null)}
+                className="rounded p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                aria-label="Fermer"
+              >
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="mt-4 space-y-6">
+              {([availabilityModalGame.homeTeamId, availabilityModalGame.awayTeamId] as const)
+                .filter((teamId) => {
+                  const team = teams.find((t) => t.id === teamId)
+                  return team && user?.clubIds?.includes(team.clubId)
+                })
+                .map((teamId) => {
+                  const team = teams.find((t) => t.id === teamId)
+                  if (!team) return null
+                  const label =
+                    teamId === availabilityModalGame.homeTeamId
+                      ? 'Équipe à domicile'
+                      : 'Équipe extérieur'
+                  const roster: Player[] = (team.playerIds ?? [])
+                    .map((pid) => players.find((p) => p.id === pid))
+                    .filter((p): p is Player => p != null)
+                  return (
+                    <div key={teamId}>
+                      <h3 className="text-sm font-medium text-slate-700 mb-2">{label}</h3>
+                      <ul className="space-y-2">
+                        {roster.length === 0 ? (
+                          <li className="text-sm text-slate-500">Aucun joueur dans l&apos;équipe</li>
+                        ) : (
+                          roster.map((player) => {
+                            const status = getAvailability(availabilityModalGame.id, player.id)
+                            const canEdit = canEditAvailability(player.id, teamId)
+                            const override = isOverride(player.id, teamId)
+                            return (
+                              <li
+                                key={player.id}
+                                className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2"
+                              >
+                                <span className="text-sm font-medium text-slate-900">
+                                  {getPlayerName(player.id)}
+                                </span>
+                                {canEdit ? (
+                                  <div className="flex gap-1">
+                                    {(['available', 'maybe', 'unavailable'] as const).map((s) => (
+                                      <button
+                                        key={s}
+                                        type="button"
+                                        onClick={() =>
+                                          setGameAvailability(
+                                            availabilityModalGame.id,
+                                            player.id,
+                                            s,
+                                            override
+                                          )
+                                        }
+                                        className={`rounded px-2 py-1 text-xs font-medium ${
+                                          status === s
+                                            ? s === 'available'
+                                              ? 'bg-green-600 text-white'
+                                              : s === 'maybe'
+                                                ? 'bg-amber-500 text-white'
+                                                : 'bg-red-600 text-white'
+                                            : 'bg-white text-slate-600 border border-slate-300 hover:bg-slate-100'
+                                        }`}
+                                      >
+                                        {availabilityLabel[s]}
+                                      </button>
+                                    ))}
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        status && clearGameAvailability(availabilityModalGame.id, player.id)
+                                      }
+                                      disabled={!status}
+                                      className="rounded px-2 py-1 text-xs font-medium bg-white text-slate-500 border border-slate-300 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-default"
+                                      title="Effacer"
+                                    >
+                                      —
+                                    </button>
+                                  </div>
+                                ) : (
+                                  <span className="text-sm text-slate-600">
+                                    {status ? availabilityLabel[status] : '—'}
+                                  </span>
+                                )}
+                              </li>
+                            )
+                          })
+                        )}
+                      </ul>
+                    </div>
+                  )
+                }
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/admin/PlayersPage.tsx
+++ b/src/pages/admin/PlayersPage.tsx
@@ -27,19 +27,24 @@ export function PlayersPage() {
   })
 
   const isClubAdmin = user?.role === 'club_admin'
+  const hasClubScope =
+    (user?.role === 'club_admin' || user?.role === 'captain' || user?.role === 'player') &&
+    (user?.clubIds?.length ?? 0) > 0
   const adminClubIds = user?.clubIds ?? []
 
   const players = useMemo(() => {
-    if (isClubAdmin && adminClubIds.length) {
-      return allPlayers.filter((p) => adminClubIds.includes(p.clubId))
+    if (hasClubScope && adminClubIds.length) {
+      return allPlayers.filter((p) => p.clubId && adminClubIds.includes(p.clubId))
     }
     return allPlayers
-  }, [allPlayers, isClubAdmin, adminClubIds])
+  }, [allPlayers, hasClubScope, adminClubIds])
 
   const clubsForSelect =
-    isClubAdmin && adminClubIds.length
+    hasClubScope && adminClubIds.length
       ? clubs.filter((c) => adminClubIds.includes(c.id))
       : clubs
+
+  const canEditPlayers = user?.role === 'general_admin' || isClubAdmin
 
   const adminClubNames = adminClubIds
     .map((id) => clubs.find((c) => c.id === id)?.displayName)
@@ -122,17 +127,19 @@ export function PlayersPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="font-display text-2xl font-semibold text-slate-800">Joueurs</h1>
-          {isClubAdmin && adminClubNames && (
+          {hasClubScope && adminClubNames && (
             <p className="mt-1 text-sm text-slate-600">Club : {adminClubNames}</p>
           )}
         </div>
-        <button
-          type="button"
-          onClick={openCreate}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          Ajouter un joueur
-        </button>
+        {canEditPlayers && (
+          <button
+            type="button"
+            onClick={openCreate}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Ajouter un joueur
+          </button>
+        )}
       </div>
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
         <table className="min-w-full divide-y divide-slate-200">
@@ -150,7 +157,7 @@ export function PlayersPage() {
               <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                 Téléphone
               </th>
-              {!isClubAdmin && (
+              {!hasClubScope && (
                 <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                   Club
                 </th>
@@ -174,7 +181,7 @@ export function PlayersPage() {
                 </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{player.email}</td>
                 <td className="px-4 py-3 text-sm text-slate-600">{player.phone || '—'}</td>
-                {!isClubAdmin && (
+                {!hasClubScope && (
                   <td className="px-4 py-3 text-sm text-slate-600">
                     {getClubName(player.clubId)}
                   </td>
@@ -193,13 +200,15 @@ export function PlayersPage() {
                   </span>
                 </td>
                 <td className="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(player)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    Modifier
-                  </button>
+                  {canEditPlayers && (
+                    <button
+                      type="button"
+                      onClick={() => openEdit(player)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/pages/admin/TeamsPage.tsx
+++ b/src/pages/admin/TeamsPage.tsx
@@ -17,15 +17,18 @@ export function TeamsPage() {
     updateGroup,
   } = useMockData()
 
+  const isClubAdmin = user?.role === 'club_admin'
+  const hasClubScope = (user?.role === 'club_admin' || user?.role === 'captain' || user?.role === 'player') && (user?.clubIds?.length ?? 0) > 0
+
   const teams = useMemo(() => {
-    if (user?.role === 'club_admin' && user.clubIds?.length) {
+    if (hasClubScope && user?.clubIds?.length) {
       return allTeams.filter((t) => user.clubIds.includes(t.clubId))
     }
     return allTeams
-  }, [allTeams, user?.role, user?.clubIds])
+  }, [allTeams, hasClubScope, user?.clubIds])
 
   const clubsForSelect =
-    user?.role === 'club_admin' && user?.clubIds?.length
+    hasClubScope && user?.clubIds?.length
       ? clubs.filter((c) => user.clubIds.includes(c.id))
       : clubs
   const [editing, setEditing] = useState<Team | null>(null)
@@ -40,6 +43,7 @@ export function TeamsPage() {
     defaultDay: '',
     defaultTime: '',
     captainId: '',
+    playerIds: [] as string[],
   })
 
   const getClubName = (clubId: string) => clubs.find((c) => c.id === clubId)?.displayName ?? clubId
@@ -60,7 +64,9 @@ export function TeamsPage() {
   const selectedClub = form.clubId ? clubs.find((c) => c.id === form.clubId) : undefined
   const addressesForClub = selectedClub?.addresses ?? []
   const playersInClub = form.clubId
-    ? players.filter((p) => p.clubId === form.clubId && p.status === 'active')
+    ? players.filter(
+        (p) => p.clubId === form.clubId && p.status === 'active' && p.clubId !== ''
+      )
     : []
 
   const openEdit = (team: Team) => {
@@ -76,6 +82,7 @@ export function TeamsPage() {
       defaultDay: team.defaultDay,
       defaultTime: team.defaultTime,
       captainId: team.captainId,
+      playerIds: team.playerIds ?? [],
     })
   }
 
@@ -87,7 +94,6 @@ export function TeamsPage() {
     const firstDiv = divisions.find((d) => d.phaseId === firstPhase?.id)
     const firstGroup = firstDiv ? groups.find((g) => g.divisionId === firstDiv.id) : undefined
     const defaultAddr = firstClub?.addresses?.find((a) => a.isDefault) ?? firstClub?.addresses?.[0]
-    const firstCaptain = firstClub ? players.find((p) => p.clubId === firstClub.id) : undefined
     setForm({
       clubId: firstClub?.id ?? '',
       phaseId: firstPhase?.id ?? '',
@@ -97,7 +103,8 @@ export function TeamsPage() {
       gameLocationId: defaultAddr?.id ?? '',
       defaultDay: 'Jeudi',
       defaultTime: '20h00',
-      captainId: firstCaptain?.id ?? '',
+      captainId: '',
+      playerIds: [],
     })
   }
 
@@ -106,6 +113,16 @@ export function TeamsPage() {
     setCreating(false)
   }
 
+  const rosterPlayers = form.playerIds
+    .map((id) => players.find((p) => p.id === id))
+    .filter(Boolean) as typeof playersInClub
+  const captainForSave =
+    form.playerIds.length === 0
+      ? ''
+      : form.playerIds.includes(form.captainId)
+        ? form.captainId
+        : form.playerIds[0] ?? ''
+
   const handleSave = () => {
     if (editing) {
       updateTeam(editing.id, {
@@ -113,12 +130,23 @@ export function TeamsPage() {
         gameLocationId: form.gameLocationId,
         defaultDay: form.defaultDay,
         defaultTime: form.defaultTime,
-        captainId: form.captainId,
+        playerIds: form.playerIds,
+        captainId: captainForSave,
       })
       closeModal()
       return
     }
-    if (!creating || !form.clubId || !form.phaseId || !form.divisionId || !form.groupId || !form.gameLocationId || !form.captainId) return
+    if (
+      !creating ||
+      !form.clubId ||
+      !form.phaseId ||
+      !form.divisionId ||
+      !form.groupId ||
+      !form.gameLocationId ||
+      form.playerIds.length === 0 ||
+      !form.playerIds.includes(form.captainId)
+    )
+      return
     const newTeam = addTeam({
       clubId: form.clubId,
       phaseId: form.phaseId,
@@ -129,6 +157,7 @@ export function TeamsPage() {
       defaultDay: form.defaultDay,
       defaultTime: form.defaultTime,
       captainId: form.captainId,
+      playerIds: form.playerIds,
     })
     const group = groups.find((g) => g.id === form.groupId)
     if (group) {
@@ -141,13 +170,15 @@ export function TeamsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="font-display text-2xl font-semibold text-slate-800">Équipes</h1>
-        <button
-          type="button"
-          onClick={openCreate}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          Ajouter une équipe
-        </button>
+        {(user?.role === 'general_admin' || isClubAdmin) && (
+          <button
+            type="button"
+            onClick={openCreate}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Ajouter une équipe
+          </button>
+        )}
       </div>
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-200">
@@ -188,13 +219,15 @@ export function TeamsPage() {
                 </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{getCaptainName(team.captainId)}</td>
                 <td className="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(team)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    Modifier
-                  </button>
+                  {(user?.role === 'general_admin' || isClubAdmin) && (
+                    <button
+                      type="button"
+                      onClick={() => openEdit(team)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -228,6 +261,7 @@ export function TeamsPage() {
                         clubId: e.target.value,
                         gameLocationId: '',
                         captainId: '',
+                        playerIds: [],
                       }))
                     }
                     disabled={!!editing}
@@ -354,16 +388,84 @@ export function TeamsPage() {
                 </div>
               </div>
               <div>
+                <label className="block text-sm font-medium text-slate-700 mb-2">
+                  Joueurs de l&apos;équipe
+                </label>
+                <p className="text-xs text-slate-500 mb-2">
+                  Joueurs du club dans cette équipe. Ajoutez ou retirez des joueurs.
+                </p>
+                <ul className="space-y-1.5 rounded-lg border border-slate-200 bg-slate-50/50 p-3 max-h-40 overflow-y-auto mb-2">
+                  {rosterPlayers.length === 0 ? (
+                    <li className="text-sm text-slate-500">Aucun joueur dans l&apos;équipe.</li>
+                  ) : (
+                    rosterPlayers.map((p) => (
+                      <li
+                        key={p.id}
+                        className="flex items-center justify-between gap-2 rounded bg-white border border-slate-200 px-2 py-1.5"
+                      >
+                        <span className="text-sm font-medium text-slate-900">
+                          {p.firstName} {p.lastName}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setForm((f) => ({
+                              ...f,
+                              playerIds: f.playerIds.filter((id) => id !== p.id),
+                              captainId: form.captainId === p.id ? '' : form.captainId,
+                            }))
+                          }}
+                          className="text-slate-500 hover:text-red-600 text-sm font-medium"
+                          title="Retirer de l'équipe"
+                        >
+                          Retirer
+                        </button>
+                      </li>
+                    ))
+                  )}
+                </ul>
+                {playersInClub.length === 0 ? (
+                  <p className="text-xs text-slate-500">Aucun joueur actif dans ce club.</p>
+                ) : (
+                  <div className="flex gap-2 items-center">
+                    <select
+                      value=""
+                      onChange={(e) => {
+                        const id = e.target.value
+                        if (id && !form.playerIds.includes(id)) {
+                          setForm((f) => ({ ...f, playerIds: [...f.playerIds, id] }))
+                        }
+                        e.target.value = ''
+                      }}
+                      className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                    >
+                      <option value="">— Ajouter un joueur —</option>
+                      {playersInClub
+                        .filter((p) => !form.playerIds.includes(p.id))
+                        .map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.firstName} {p.lastName}
+                          </option>
+                        ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+              <div>
                 <label htmlFor="team-captainId" className="block text-sm font-medium text-slate-700">
                   Capitaine
                 </label>
+                <p className="text-xs text-slate-500 mb-1">
+                  Le capitaine doit faire partie des joueurs de l&apos;équipe ci-dessus.
+                </p>
                 <select
                   id="team-captainId"
-                  value={form.captainId}
+                  value={form.playerIds.includes(form.captainId) ? form.captainId : ''}
                   onChange={(e) => setForm((f) => ({ ...f, captainId: e.target.value }))}
                   className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
                 >
-                  {playersInClub.map((p) => (
+                  <option value="">— Choisir un capitaine —</option>
+                  {rosterPlayers.map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.firstName} {p.lastName}
                     </option>
@@ -389,7 +491,8 @@ export function TeamsPage() {
                     !form.divisionId ||
                     !form.groupId ||
                     !form.gameLocationId ||
-                    !form.captainId)
+                    form.playerIds.length === 0 ||
+                    !form.playerIds.includes(form.captainId))
                 }
                 className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
               >

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,7 +73,22 @@ export interface Team {
   defaultDay: string
   defaultTime: string
   captainId: string
+  /** Roster for this team (phase). Used for availability and game selection. */
+  playerIds: string[]
   whatsappLink?: string
+}
+
+export type AvailabilityStatus = 'available' | 'maybe' | 'unavailable'
+
+export type AvailabilityOverriddenBy = 'captain' | 'club_admin'
+
+export interface GameAvailability {
+  id: string
+  gameId: string
+  playerId: string
+  status: AvailabilityStatus
+  /** Set when captain or club admin overrides the player's choice */
+  overriddenBy?: AvailabilityOverriddenBy
 }
 
 export interface MatchDay {


### PR DESCRIPTION
## Game availability and related (issue #5)

### Game availability
- Per game, players set availability: **Available** / **Maybe** / **Not available**
- Edit: player (self), captain (their team), club admin (their club). Global admin has no edit.
- View: only club members (home or away); opponent team roster/names hidden in modal
- Clear availability (—) to unset

### Captain & player
- Nav: **Équipes**, **Journées**, **Joueurs** (same as club admin for their club)
- Header shows "Club : …" for captain/player
- Teams page: list filtered to their club; no Add/Edit for captain/player
- Players page: list filtered to their club; no Add/Edit for captain/player
- Journées: can open Disponibilités for games involving their club

### Team roster
- Team create/edit: roster via **add/remove** (dropdown + Retirer), no checkboxes
- Captain must be chosen from the team roster only
- Only players from the selected club

### Mock & plan
- Global admin not attached to any club (`clubIds: []`, player `clubId: ''`)
- Implementation plan: **Status** column removed; status comes from the linked GitHub issue

Closes #5

Made with [Cursor](https://cursor.com)