### PR TITLE
Player–team assignment and points (#10)

### DIFF
--- a/src/contexts/MockDataContext.tsx
+++ b/src/contexts/MockDataContext.tsx
@@ -136,9 +136,37 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const updateTeam = useCallback((id: string, patch: Partial<Team>) => {
-    setTeams((prev) =>
-      prev.map((t) => (t.id === id ? { ...t, ...patch } : t))
-    )
+    setTeams((prev) => {
+      const team = prev.find((t) => t.id === id)
+      if (!team) return prev
+      const nextPlayerIds = patch.playerIds ?? team.playerIds ?? []
+      const phaseId = patch.phaseId ?? team.phaseId
+      const rosterInitialPoints = patch.rosterInitialPoints ?? team.rosterInitialPoints
+      const otherTeamsInPhase = prev.filter(
+        (t) => t.phaseId === phaseId && t.id !== id
+      )
+      const updates: Array<{ id: string; playerIds: string[]; rosterInitialPoints?: Record<string, string> }> = []
+      for (const other of otherTeamsInPhase) {
+        const otherIds = other.playerIds ?? []
+        const removed = otherIds.filter((pid) => nextPlayerIds.includes(pid))
+        if (removed.length > 0) {
+          const nextIds = otherIds.filter((pid) => !nextPlayerIds.includes(pid))
+          const nextPoints = { ...other.rosterInitialPoints }
+          removed.forEach((pid) => delete nextPoints[pid])
+          updates.push({
+            id: other.id,
+            playerIds: nextIds,
+            rosterInitialPoints: Object.keys(nextPoints).length ? nextPoints : undefined,
+          })
+        }
+      }
+      return prev.map((t) => {
+        if (t.id === id) return { ...t, ...patch, rosterInitialPoints }
+        const u = updates.find((u) => u.id === t.id)
+        if (u) return { ...t, playerIds: u.playerIds, rosterInitialPoints: u.rosterInitialPoints }
+        return t
+      })
+    })
   }, [])
 
   const addClub = useCallback((data: Omit<Club, 'id'>) => {
@@ -179,7 +207,26 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
   const addTeam = useCallback((data: Omit<Team, 'id'>) => {
     const id = nextId('team')
     const team: Team = { ...data, id }
-    setTeams((prev) => [...prev, team])
+    setTeams((prev) => {
+      const phaseId = team.phaseId
+      const newPlayerIds = team.playerIds ?? []
+      const otherTeamsInPhase = prev.filter((t) => t.phaseId === phaseId)
+      const updated = prev.map((t) => {
+        if (!otherTeamsInPhase.includes(t)) return t
+        const otherIds = t.playerIds ?? []
+        const removed = otherIds.filter((pid) => newPlayerIds.includes(pid))
+        if (removed.length === 0) return t
+        const nextIds = otherIds.filter((pid) => !newPlayerIds.includes(pid))
+        const nextPoints = { ...t.rosterInitialPoints }
+        removed.forEach((pid) => delete nextPoints[pid])
+        return {
+          ...t,
+          playerIds: nextIds,
+          rosterInitialPoints: Object.keys(nextPoints).length ? nextPoints : undefined,
+        }
+      })
+      return [...updated, team]
+    })
     return team
   }, [])
 

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -61,6 +61,7 @@ export const mockPlayers: Player[] = [
   { id: 'player-16', firstName: 'Julie', lastName: 'Bitschwiller', licenseNumber: '6814439', email: 'julie@bitschwiller.example.com', phone: '', status: 'active', clubId: 'club-7' },
   { id: 'player-17', firstName: 'Noah', lastName: 'Cernay', licenseNumber: '6814440', email: 'noah@cernay.example.com', phone: '', status: 'active', clubId: 'club-8' },
   { id: 'player-18', firstName: 'Jade', lastName: 'Cernay', licenseNumber: '6814441', email: 'jade@cernay.example.com', phone: '', status: 'active', clubId: 'club-8' },
+  { id: 'player-19', firstName: 'Inès', lastName: 'Rixheim', licenseNumber: '6814442', email: 'ines@rixheim.example.com', phone: '', status: 'active', clubId: 'club-1' },
 ]
 
 export const mockGroups: Group[] = [
@@ -80,6 +81,7 @@ export const mockTeams: Team[] = [
     defaultTime: '20h00',
     captainId: 'player-1',
     playerIds: ['player-1', 'player-3', 'player-4'],
+    rosterInitialPoints: { 'player-1': '850', 'player-3': '720', 'player-4': '680' },
     color: '#374151',
   },
   {
@@ -113,7 +115,8 @@ export const mockTeams: Team[] = [
     defaultDay: 'Jeudi',
     defaultTime: '20h00',
     captainId: 'player-6',
-    playerIds: ['player-6', 'player-3', 'player-4'],
+    playerIds: ['player-6', 'player-19'],
+    rosterInitialPoints: { 'player-6': '920', 'player-19': '650' },
     color: '#65a30d',
   },
 ]

--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -787,7 +787,7 @@ export function MatchDaysPage() {
                               {player.licenseNumber || '—'}
                             </td>
                             <td className="whitespace-nowrap px-3 py-2 text-slate-600">
-                              {player.points ?? '—'}
+                              {(team.rosterInitialPoints?.[player.id] ?? player.points) || '—'}
                             </td>
                             <td className="whitespace-nowrap px-3 py-2 text-center text-slate-600">
                               {availCount}/{teamGamesCount}

--- a/src/pages/admin/TeamsPage.tsx
+++ b/src/pages/admin/TeamsPage.tsx
@@ -44,6 +44,8 @@ export function TeamsPage() {
     defaultTime: '',
     captainId: '',
     playerIds: [] as string[],
+    /** Initial points per player for this phase (when in this team). */
+    initialPoints: {} as Record<string, string>,
   })
 
   const getClubName = (clubId: string) => clubs.find((c) => c.id === clubId)?.displayName ?? clubId
@@ -72,6 +74,11 @@ export function TeamsPage() {
   const openEdit = (team: Team) => {
     setEditing(team)
     setCreating(false)
+    const rosterIds = team.playerIds ?? []
+    const initialPoints: Record<string, string> = {}
+    rosterIds.forEach((pid) => {
+      initialPoints[pid] = team.rosterInitialPoints?.[pid] ?? players.find((p) => p.id === pid)?.points ?? ''
+    })
     setForm({
       clubId: team.clubId,
       phaseId: team.phaseId,
@@ -82,7 +89,8 @@ export function TeamsPage() {
       defaultDay: team.defaultDay,
       defaultTime: team.defaultTime,
       captainId: team.captainId,
-      playerIds: team.playerIds ?? [],
+      playerIds: rosterIds,
+      initialPoints,
     })
   }
 
@@ -105,6 +113,7 @@ export function TeamsPage() {
       defaultTime: '20h00',
       captainId: '',
       playerIds: [],
+      initialPoints: {},
     })
   }
 
@@ -123,6 +132,14 @@ export function TeamsPage() {
         ? form.captainId
         : form.playerIds[0] ?? ''
 
+  const buildRosterInitialPoints = (): Record<string, string> | undefined => {
+    const out: Record<string, string> = {}
+    form.playerIds.forEach((pid) => {
+      out[pid] = (form.initialPoints[pid] ?? '').trim()
+    })
+    return form.playerIds.length > 0 ? out : undefined
+  }
+
   const handleSave = () => {
     if (editing) {
       updateTeam(editing.id, {
@@ -132,6 +149,7 @@ export function TeamsPage() {
         defaultTime: form.defaultTime,
         playerIds: form.playerIds,
         captainId: captainForSave,
+        rosterInitialPoints: buildRosterInitialPoints(),
       })
       closeModal()
       return
@@ -158,6 +176,7 @@ export function TeamsPage() {
       defaultTime: form.defaultTime,
       captainId: form.captainId,
       playerIds: form.playerIds,
+      rosterInitialPoints: buildRosterInitialPoints(),
     })
     const group = groups.find((g) => g.id === form.groupId)
     if (group) {
@@ -394,7 +413,7 @@ export function TeamsPage() {
                 <p className="text-xs text-slate-500 mb-2">
                   Joueurs du club dans cette équipe. Ajoutez ou retirez des joueurs.
                 </p>
-                <ul className="space-y-1.5 rounded-lg border border-slate-200 bg-slate-50/50 p-3 max-h-40 overflow-y-auto mb-2">
+                <ul className="space-y-1.5 rounded-lg border border-slate-200 bg-slate-50/50 p-3 max-h-48 overflow-y-auto mb-2">
                   {rosterPlayers.length === 0 ? (
                     <li className="text-sm text-slate-500">Aucun joueur dans l&apos;équipe.</li>
                   ) : (
@@ -403,19 +422,39 @@ export function TeamsPage() {
                         key={p.id}
                         className="flex items-center justify-between gap-2 rounded bg-white border border-slate-200 px-2 py-1.5"
                       >
-                        <span className="text-sm font-medium text-slate-900">
+                        <span className="text-sm font-medium text-slate-900 shrink-0">
                           {p.firstName} {p.lastName}
                         </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                          <label className="text-xs text-slate-500 whitespace-nowrap">Points (phase)</label>
+                          <input
+                            type="text"
+                            value={form.initialPoints[p.id] ?? ''}
+                            onChange={(e) =>
+                              setForm((f) => ({
+                                ...f,
+                                initialPoints: { ...f.initialPoints, [p.id]: e.target.value },
+                              }))
+                            }
+                            placeholder="—"
+                            className="w-16 rounded border border-slate-300 px-1.5 py-0.5 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500/20"
+                          />
+                        </div>
                         <button
                           type="button"
                           onClick={() => {
-                            setForm((f) => ({
-                              ...f,
-                              playerIds: f.playerIds.filter((id) => id !== p.id),
-                              captainId: form.captainId === p.id ? '' : form.captainId,
-                            }))
+                            setForm((f) => {
+                              const next = { ...f.initialPoints }
+                              delete next[p.id]
+                              return {
+                                ...f,
+                                playerIds: f.playerIds.filter((id) => id !== p.id),
+                                captainId: form.captainId === p.id ? '' : form.captainId,
+                                initialPoints: next,
+                              }
+                            })
                           }}
-                          className="text-slate-500 hover:text-red-600 text-sm font-medium"
+                          className="text-slate-500 hover:text-red-600 text-sm font-medium shrink-0"
                           title="Retirer de l'équipe"
                         >
                           Retirer
@@ -433,7 +472,12 @@ export function TeamsPage() {
                       onChange={(e) => {
                         const id = e.target.value
                         if (id && !form.playerIds.includes(id)) {
-                          setForm((f) => ({ ...f, playerIds: [...f.playerIds, id] }))
+                          const p = players.find((x) => x.id === id)
+                          setForm((f) => ({
+                            ...f,
+                            playerIds: [...f.playerIds, id],
+                            initialPoints: { ...f.initialPoints, [id]: p?.points ?? '' },
+                          }))
                         }
                         e.target.value = ''
                       }}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,8 @@ export interface Team {
   captainId: string
   /** Roster for this team (phase). Used for availability and game selection. */
   playerIds: string[]
+  /** Initial points per player at the start of the phase (Club Admin sets when defining roster). */
+  rosterInitialPoints?: Record<string, string>
   /** Optional hex color for table/header display (e.g. #374151). */
   color?: string
   whatsappLink?: string


### PR DESCRIPTION
Closes #10

## Summary
- **Per phase**: Player assigned to at most one team; initial (locked) points for the phase when assigned to a team.
- **Club Admin**: Define team roster and set **initial points** per player when defining the roster.

### Changes
- **Types**: `Team.rosterInitialPoints?: Record<string, string>` — initial points per player for the phase.
- **Enforce one team per phase**: When saving a team roster (`updateTeam` / `addTeam`), remove each roster player from any other team in the same phase (and clear their points there).
- **TeamsPage**: "Points (phase)" input per roster player; load/save `rosterInitialPoints`; new roster members get default from `player.points`.
- **MatchDaysPage**: Points column uses `team.rosterInitialPoints?.[player.id]` with fallback to `player.points`.
- **Mock**: `rosterInitialPoints` on team-1 and team-9; added player-19 (Inès Rixheim, club-1); team-9 roster no longer overlaps team-1.

Made with [Cursor](https://cursor.com)