### PR TITLE
Club detail view, My Club page, admin URL by affiliation number

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { AppShell } from '@/components/AppShell'
 import { LoginPage } from '@/pages/LoginPage'
 import { HomePage } from '@/pages/HomePage'
 import { ClubsPage } from '@/pages/admin/ClubsPage'
+import { ClubDetailPage } from '@/pages/admin/ClubDetailPage'
 import { SeasonsPage } from '@/pages/admin/SeasonsPage'
 import { PhasesPage } from '@/pages/admin/PhasesPage'
 import { DivisionsPage } from '@/pages/admin/DivisionsPage'
@@ -12,6 +13,7 @@ import { GroupsPage } from '@/pages/admin/GroupsPage'
 import { TeamsPage } from '@/pages/admin/TeamsPage'
 import { PlayersPage } from '@/pages/admin/PlayersPage'
 import { MatchDaysPage } from '@/pages/admin/MatchDaysPage'
+import { MyClubPage } from '@/pages/MyClubPage'
 
 function ProtectedLayout() {
   const { isAuthenticated } = useAuth()
@@ -39,6 +41,7 @@ export default function App() {
           <Route path="/" element={<ProtectedLayout />}>
             <Route index element={<HomePage />} />
             <Route path="clubs" element={<ClubsPage />} />
+            <Route path="clubs/:affiliationNumber" element={<ClubDetailPage />} />
             <Route path="saisons" element={<SeasonsPage />} />
             <Route path="phases" element={<PhasesPage />} />
             <Route path="divisions" element={<DivisionsPage />} />
@@ -46,6 +49,7 @@ export default function App() {
             <Route path="equipes" element={<TeamsPage />} />
             <Route path="joueurs" element={<PlayersPage />} />
             <Route path="journees" element={<MatchDaysPage />} />
+            <Route path="mon-club" element={<MyClubPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -59,6 +59,11 @@ export function AppShell() {
             )}
             {(isClubAdmin || user?.role === 'captain' || user?.role === 'player') && !isGeneralAdmin && (
               <>
+                {user?.clubIds?.length ? (
+                  <Link to="/mon-club" className={navLinkClass(location.pathname === '/mon-club')}>
+                    Mon club
+                  </Link>
+                ) : null}
                 <Link to="/equipes" className={navLinkClass(location.pathname === '/equipes')}>
                   Équipes
                 </Link>

--- a/src/components/ClubDetailView.tsx
+++ b/src/components/ClubDetailView.tsx
@@ -1,0 +1,295 @@
+import { useState, useEffect } from 'react'
+import type { Address, Club } from '@/types'
+import { useMockData } from '@/contexts/MockDataContext'
+import { useClubAddressFormState } from '@/pages/useClubAddressForm'
+
+const emptyAddressForm = {
+  label: '',
+  street: '',
+  postalCode: '',
+  city: '',
+  isDefault: false,
+}
+
+export interface ClubDetailViewProps {
+  club: Club
+  canEdit: boolean
+  /** When true, N° affiliation can be edited (reserved for global admin). Default false. */
+  canEditAffiliationNumber?: boolean
+  /** Called after saving club (e.g. to navigate to new URL if affiliation number changed). */
+  onClubSaved?: (patch: { affiliationNumber: string; displayName: string }) => void
+  /** Prefix for input ids to avoid duplicates when multiple instances exist. */
+  idPrefix?: string
+}
+
+export function ClubDetailView({
+  club,
+  canEdit,
+  canEditAffiliationNumber = false,
+  onClubSaved,
+  idPrefix = 'club-detail',
+}: ClubDetailViewProps) {
+  const { updateClub, addClubAddress, updateClubAddress, deleteClubAddress } = useMockData()
+  const [form, setForm] = useState({ affiliationNumber: club.affiliationNumber, displayName: club.displayName })
+  const [addressForm, setAddressForm] = useClubAddressFormState()
+  const [addressFields, setAddressFields] = useState(emptyAddressForm)
+
+  useEffect(() => {
+    setForm({
+      affiliationNumber: club.affiliationNumber,
+      displayName: club.displayName,
+    })
+  }, [club.id, club.affiliationNumber, club.displayName])
+
+  const handleSaveClub = () => {
+    updateClub(club.id, form)
+    onClubSaved?.(form)
+  }
+
+  const openAddAddress = () => {
+    setAddressForm({ mode: 'add' })
+    setAddressFields(emptyAddressForm)
+  }
+
+  const openEditAddress = (address: Address) => {
+    setAddressForm({ mode: 'edit', address })
+    setAddressFields({
+      label: address.label,
+      street: address.street,
+      postalCode: address.postalCode,
+      city: address.city,
+      isDefault: address.isDefault,
+    })
+  }
+
+  const closeAddressForm = () => {
+    setAddressForm(null)
+  }
+
+  const handleSaveAddress = () => {
+    if (addressForm?.mode === 'add') {
+      addClubAddress(club.id, addressFields)
+      closeAddressForm()
+    } else if (addressForm?.mode === 'edit') {
+      updateClubAddress(club.id, addressForm.address.id, addressFields)
+      closeAddressForm()
+    }
+  }
+
+  const handleDeleteAddress = (addressId: string) => {
+    if (window.confirm('Supprimer cette adresse ?')) {
+      deleteClubAddress(club.id, addressId)
+      if (addressForm?.mode === 'edit' && addressForm.address.id === addressId) {
+        closeAddressForm()
+      }
+    }
+  }
+
+  const handleSetDefaultAddress = (addressId: string) => {
+    updateClubAddress(club.id, addressId, { isDefault: true })
+  }
+
+  const addresses = club.addresses ?? []
+
+  return (
+    <>
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="font-display text-lg font-medium text-slate-800">Informations du club</h2>
+        <div className="mt-4 space-y-4">
+          <div>
+            <label
+              htmlFor={`${idPrefix}-affiliationNumber`}
+              className="block text-sm font-medium text-slate-700"
+            >
+              N° affiliation
+            </label>
+            <input
+              id={`${idPrefix}-affiliationNumber`}
+              type="text"
+              value={form.affiliationNumber}
+              onChange={(e) =>
+                canEdit &&
+                canEditAffiliationNumber &&
+                setForm((f) => ({ ...f, affiliationNumber: e.target.value }))
+              }
+              readOnly={!canEdit || !canEditAffiliationNumber}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:bg-slate-50 disabled:text-slate-600"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={`${idPrefix}-displayName`}
+              className="block text-sm font-medium text-slate-700"
+            >
+              Nom
+            </label>
+            <input
+              id={`${idPrefix}-displayName`}
+              type="text"
+              value={form.displayName}
+              onChange={(e) => canEdit && setForm((f) => ({ ...f, displayName: e.target.value }))}
+              readOnly={!canEdit}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:bg-slate-50 disabled:text-slate-600"
+            />
+          </div>
+        </div>
+        {canEdit && (
+          <div className="mt-4 flex justify-end">
+            <button
+              type="button"
+              onClick={handleSaveClub}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              Enregistrer
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-lg font-medium text-slate-800">
+            Adresses (lieux de jeu)
+          </h2>
+          {canEdit && (
+            <button
+              type="button"
+              onClick={openAddAddress}
+              className="text-sm font-medium text-blue-600 hover:text-blue-800"
+            >
+              Ajouter une adresse
+            </button>
+          )}
+        </div>
+        <ul className="mt-4 space-y-2 rounded-lg border border-slate-200 bg-slate-50/50 p-3">
+          {addresses.length === 0 && !addressForm && (
+            <li className="text-sm text-slate-500">Aucune adresse.</li>
+          )}
+          {addresses.map((a) => (
+            <li
+              key={a.id}
+              className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+            >
+              <div>
+                <span className="font-medium text-slate-900">{a.label}</span>
+                {a.isDefault && (
+                  <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-700">
+                    Par défaut
+                  </span>
+                )}
+                <p className="text-slate-600">
+                  {a.street}, {a.postalCode} {a.city}
+                </p>
+              </div>
+              {canEdit && (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => openEditAddress(a)}
+                    className="text-blue-600 hover:text-blue-800"
+                  >
+                    Modifier
+                  </button>
+                  {!a.isDefault && (
+                    <button
+                      type="button"
+                      onClick={() => handleSetDefaultAddress(a.id)}
+                      className="text-slate-600 hover:text-slate-800"
+                    >
+                      Par défaut
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteAddress(a.id)}
+                    className="text-red-600 hover:text-red-800"
+                  >
+                    Supprimer
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {canEdit && addressForm && (
+          <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-4">
+            <h3 className="text-sm font-medium text-slate-700">
+              {addressForm.mode === 'add' ? 'Nouvelle adresse' : "Modifier l'adresse"}
+            </h3>
+            <div className="mt-3 space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-slate-600">Libellé</label>
+                <input
+                  type="text"
+                  value={addressFields.label}
+                  onChange={(e) => setAddressFields((f) => ({ ...f, label: e.target.value }))}
+                  placeholder="ex. Gymnase principal"
+                  className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-slate-600">Rue</label>
+                <input
+                  type="text"
+                  value={addressFields.street}
+                  onChange={(e) => setAddressFields((f) => ({ ...f, street: e.target.value }))}
+                  className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                />
+              </div>
+              <div className="flex gap-2">
+                <div className="flex-1">
+                  <label className="block text-xs font-medium text-slate-600">Code postal</label>
+                  <input
+                    type="text"
+                    value={addressFields.postalCode}
+                    onChange={(e) =>
+                      setAddressFields((f) => ({ ...f, postalCode: e.target.value }))
+                    }
+                    className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  />
+                </div>
+                <div className="flex-[2]">
+                  <label className="block text-xs font-medium text-slate-600">Ville</label>
+                  <input
+                    type="text"
+                    value={addressFields.city}
+                    onChange={(e) => setAddressFields((f) => ({ ...f, city: e.target.value }))}
+                    className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+                  />
+                </div>
+              </div>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={addressFields.isDefault}
+                  onChange={(e) =>
+                    setAddressFields((f) => ({ ...f, isDefault: e.target.checked }))
+                  }
+                  className="rounded border-slate-300"
+                />
+                <span className="text-sm text-slate-700">Adresse par défaut</span>
+              </label>
+            </div>
+            <div className="mt-3 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeAddressForm}
+                className="rounded bg-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-300"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveAddress}
+                className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+              >
+                Enregistrer
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/contexts/MockDataContext.tsx
+++ b/src/contexts/MockDataContext.tsx
@@ -20,6 +20,7 @@ import {
   mockGameSelections as initialGameSelections,
 } from '@/mock/data'
 import type {
+  Address,
   Club,
   Season,
   Phase,
@@ -55,6 +56,9 @@ function nextId(prefix: string): string {
 interface MockDataContextValue extends MockDataState {
   updateDivision: (id: string, patch: Partial<Division>) => void
   updateClub: (id: string, patch: Partial<Club>) => void
+  addClubAddress: (clubId: string, data: Omit<Address, 'id'>) => Address
+  updateClubAddress: (clubId: string, addressId: string, patch: Partial<Address>) => void
+  deleteClubAddress: (clubId: string, addressId: string) => void
   updateSeason: (id: string, patch: Partial<Season>) => void
   updatePhase: (id: string, patch: Partial<Phase>) => void
   updateGroup: (id: string, patch: Partial<Group>) => void
@@ -118,6 +122,53 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
   const updateClub = useCallback((id: string, patch: Partial<Club>) => {
     setClubs((prev) =>
       prev.map((c) => (c.id === id ? { ...c, ...patch } : c))
+    )
+  }, [])
+
+  const addClubAddress = useCallback((clubId: string, data: Omit<Address, 'id'>) => {
+    const id = nextId('addr')
+    const address: Address = { ...data, id }
+    setClubs((prev) =>
+      prev.map((c) => {
+        if (c.id !== clubId) return c
+        const addresses = c.addresses ?? []
+        const newAddresses = data.isDefault
+          ? [...addresses.map((a) => ({ ...a, isDefault: false })), address]
+          : addresses.length === 0
+            ? [{ ...address, isDefault: true }]
+            : [...addresses, address]
+        return { ...c, addresses: newAddresses }
+      })
+    )
+    return address
+  }, [])
+
+  const updateClubAddress = useCallback(
+    (clubId: string, addressId: string, patch: Partial<Address>) => {
+      setClubs((prev) =>
+        prev.map((c) => {
+          if (c.id !== clubId) return c
+          const addresses = (c.addresses ?? []).map((a) =>
+            a.id === addressId ? { ...a, ...patch } : patch.isDefault === true ? { ...a, isDefault: false } : a
+          )
+          return { ...c, addresses }
+        })
+      )
+    },
+    []
+  )
+
+  const deleteClubAddress = useCallback((clubId: string, addressId: string) => {
+    setClubs((prev) =>
+      prev.map((c) => {
+        if (c.id !== clubId) return c
+        let addresses = (c.addresses ?? []).filter((a) => a.id !== addressId)
+        const deletedWasDefault = (c.addresses ?? []).find((a) => a.id === addressId)?.isDefault
+        if (deletedWasDefault && addresses.length > 0 && !addresses.some((a) => a.isDefault)) {
+          addresses = [{ ...addresses[0], isDefault: true }, ...addresses.slice(1)]
+        }
+        return { ...c, addresses }
+      })
     )
   }, [])
 
@@ -389,6 +440,9 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       games,
       updateDivision,
       updateClub,
+      addClubAddress,
+      updateClubAddress,
+      deleteClubAddress,
       updateSeason,
       updatePhase,
       updateGroup,
@@ -427,6 +481,9 @@ export function MockDataProvider({ children }: { children: React.ReactNode }) {
       games,
       updateDivision,
       updateClub,
+      addClubAddress,
+      updateClubAddress,
+      deleteClubAddress,
       updateSeason,
       updatePhase,
       updateGroup,

--- a/src/pages/MyClubPage.tsx
+++ b/src/pages/MyClubPage.tsx
@@ -1,0 +1,40 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { useMockData } from '@/contexts/MockDataContext'
+import { ClubDetailView } from '@/components/ClubDetailView'
+
+export function MyClubPage() {
+  const { user } = useAuth()
+  const { clubs } = useMockData()
+
+  const clubId =
+    user && user.clubIds && user.clubIds.length > 0 ? user.clubIds[0] : null
+  const currentClub = clubId
+    ? (clubs.find((c) => c.id === clubId) ?? null)
+    : null
+  const canEdit = user !== null && user.role === 'club_admin'
+
+  if (!user?.clubIds?.length || !clubId) {
+    return <Navigate to="/" replace />
+  }
+
+  if (!currentClub) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-6">
+        <p className="text-slate-600">Club introuvable.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="font-display text-2xl font-semibold text-slate-800">Mon club</h1>
+      {!canEdit && (
+        <p className="text-sm text-slate-600">
+          Seul l’administrateur du club peut modifier les informations et adresses.
+        </p>
+      )}
+      <ClubDetailView club={currentClub} canEdit={canEdit} idPrefix="my-club" />
+    </div>
+  )
+}

--- a/src/pages/admin/ClubDetailPage.tsx
+++ b/src/pages/admin/ClubDetailPage.tsx
@@ -1,0 +1,47 @@
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useMockData } from '@/contexts/MockDataContext'
+import { ClubDetailView } from '@/components/ClubDetailView'
+
+export function ClubDetailPage() {
+  const { affiliationNumber } = useParams<{ affiliationNumber: string }>()
+  const navigate = useNavigate()
+  const { clubs } = useMockData()
+  const club =
+    affiliationNumber != null
+      ? clubs.find((c) => c.affiliationNumber === affiliationNumber) ?? null
+      : null
+
+  if (!affiliationNumber || !club) {
+    return (
+      <div className="space-y-6">
+        <p className="text-slate-600">Club introuvable.</p>
+        <Link to="/clubs" className="text-sm font-medium text-blue-600 hover:text-blue-800">
+          ← Retour à la liste des clubs
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <Link
+          to="/clubs"
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-600 hover:text-slate-800"
+        >
+          ← Retour à la liste des clubs
+        </Link>
+        <h1 className="font-display text-2xl font-semibold text-slate-800">{club.displayName}</h1>
+      </div>
+      <ClubDetailView
+        club={club}
+        canEdit
+        canEditAffiliationNumber
+        onClubSaved={({ affiliationNumber: newNum }) =>
+          navigate(`/clubs/${encodeURIComponent(newNum)}`, { replace: true })
+        }
+        idPrefix="admin-club"
+      />
+    </div>
+  )
+}

--- a/src/pages/admin/ClubsPage.tsx
+++ b/src/pages/admin/ClubsPage.tsx
@@ -1,36 +1,32 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import type { Club } from '@/types'
 import { useMockData } from '@/contexts/MockDataContext'
 
 export function ClubsPage() {
-  const { clubs, updateClub, addClub } = useMockData()
-  const [editing, setEditing] = useState<Club | null>(null)
+  const navigate = useNavigate()
+  const { clubs, addClub } = useMockData()
   const [creating, setCreating] = useState(false)
   const [form, setForm] = useState({ affiliationNumber: '', displayName: '' })
 
   const openEdit = (club: Club) => {
-    setEditing(club)
-    setCreating(false)
-    setForm({
-      affiliationNumber: club.affiliationNumber,
-      displayName: club.displayName,
-    })
+    navigate(`/clubs/${club.affiliationNumber}`)
   }
 
   const openCreate = () => {
-    setEditing(null)
     setCreating(true)
     setForm({ affiliationNumber: '', displayName: '' })
   }
 
   const handleSave = () => {
-    if (editing) {
-      updateClub(editing.id, form)
-      setEditing(null)
-    } else if (creating) {
+    if (creating) {
       addClub({ ...form, addresses: [] })
       setCreating(false)
     }
+  }
+
+  const closeCreateModal = () => {
+    setCreating(false)
   }
 
   return (
@@ -66,10 +62,12 @@ export function ClubsPage() {
           <tbody className="divide-y divide-slate-200 bg-white">
             {clubs.map((club) => (
               <tr key={club.id} className="hover:bg-slate-50/50">
-                <td className="px-4 py-3 text-sm text-slate-900 font-mono">{club.affiliationNumber}</td>
+                <td className="px-4 py-3 text-sm text-slate-900 font-mono">
+                  {club.affiliationNumber}
+                </td>
                 <td className="px-4 py-3 text-sm font-medium text-slate-900">{club.displayName}</td>
                 <td className="px-4 py-3 text-sm text-slate-600">
-                  {club.addresses.map((a) => a.label).join(', ')}
+                  {(club.addresses ?? []).map((a) => a.label).join(', ') || '—'}
                 </td>
                 <td className="px-4 py-3 text-right">
                   <button
@@ -86,24 +84,27 @@ export function ClubsPage() {
         </table>
       </div>
 
-      {(editing || creating) && (
+      {creating && (
         <div
           className="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/50 p-4"
           role="dialog"
           aria-modal="true"
-          aria-labelledby="edit-club-title"
+          aria-labelledby="create-club-title"
         >
-          <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-lg">
-            <h2 id="edit-club-title" className="font-display text-lg font-semibold text-slate-800">
-              {creating ? 'Ajouter un club' : 'Modifier le club'}
+          <div className="w-full max-w-lg rounded-xl bg-white p-6 shadow-lg">
+            <h2 id="create-club-title" className="font-display text-lg font-semibold text-slate-800">
+              Ajouter un club
             </h2>
             <div className="mt-4 space-y-4">
               <div>
-                <label htmlFor="edit-affiliationNumber" className="block text-sm font-medium text-slate-700">
+                <label
+                  htmlFor="create-affiliationNumber"
+                  className="block text-sm font-medium text-slate-700"
+                >
                   N° affiliation
                 </label>
                 <input
-                  id="edit-affiliationNumber"
+                  id="create-affiliationNumber"
                   type="text"
                   value={form.affiliationNumber}
                   onChange={(e) => setForm((f) => ({ ...f, affiliationNumber: e.target.value }))}
@@ -111,11 +112,14 @@ export function ClubsPage() {
                 />
               </div>
               <div>
-                <label htmlFor="edit-displayName" className="block text-sm font-medium text-slate-700">
+                <label
+                  htmlFor="create-displayName"
+                  className="block text-sm font-medium text-slate-700"
+                >
                   Nom
                 </label>
                 <input
-                  id="edit-displayName"
+                  id="create-displayName"
                   type="text"
                   value={form.displayName}
                   onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
@@ -126,7 +130,7 @@ export function ClubsPage() {
             <div className="mt-6 flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => { setEditing(null); setCreating(false) }}
+                onClick={closeCreateModal}
                 className="rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200"
               >
                 Annuler

--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, Fragment, useRef, useEffect, useLayoutEffect } from 'react'
 import { createPortal } from 'react-dom'
-import type { MatchDay, Game, AvailabilityStatus, Player } from '@/types'
+import type { MatchDay, AvailabilityStatus, Player } from '@/types'
 import { useAuth } from '@/contexts/AuthContext'
 import { useMockData } from '@/contexts/MockDataContext'
 
@@ -183,13 +183,6 @@ export function MatchDaysPage() {
   } = useMockData()
   const [selectedPhaseId, setSelectedPhaseId] = useState<string>(phases[0]?.id ?? '')
 
-  const phaseGroups = useMemo(() => {
-    return groups.filter((g) => {
-      const div = divisions.find((d) => d.id === g.divisionId)
-      return div?.phaseId === selectedPhaseId
-    })
-  }, [groups, divisions, selectedPhaseId])
-
   /** All teams of the user's club in the selected phase (one block per team; each team has its own group's match-days). */
   const myClubTeamsInPhase = useMemo(() => {
     if (!selectedPhaseId || !user?.clubIds?.length) return []
@@ -277,15 +270,6 @@ export function MatchDaysPage() {
     return a?.status
   }
 
-  /** Can view availability for this game (member of home or away club). Edit is separate. */
-  const canViewGameAvailability = (game: Game): boolean => {
-    if (!user?.clubIds?.length) return false
-    const homeTeam = teams.find((t) => t.id === game.homeTeamId)
-    const awayTeam = teams.find((t) => t.id === game.awayTeamId)
-    if (!homeTeam || !awayTeam) return false
-    return user.clubIds.includes(homeTeam.clubId) || user.clubIds.includes(awayTeam.clubId)
-  }
-
   /** Only player (self), captain (their team), or club_admin (their club). Global admin has no edit. */
   const canEditAvailability = (playerId: string, teamId: string): boolean => {
     if (!user) return false
@@ -364,46 +348,6 @@ export function MatchDaysPage() {
       )
     }
     if (updates.length > 0) setGameSelectionBatch(updates)
-  }
-
-  /** Set which team this player is selected for in this game (null = remove from both). */
-  const setPlayerSelectedForGame = (gameId: string, playerId: string, teamId: string | null) => {
-    const game = games.find((g) => g.id === gameId)
-    if (!game) return
-    const homeIds = getGameSelectionPlayerIds(gameId, game.homeTeamId).filter((id) => id !== playerId)
-    const awayIds = getGameSelectionPlayerIds(gameId, game.awayTeamId).filter((id) => id !== playerId)
-    if (teamId === game.homeTeamId) homeIds.push(playerId)
-    else if (teamId === game.awayTeamId) awayIds.push(playerId)
-    setGameSelectionBatch([
-      { gameId, teamId: game.homeTeamId, playerIds: homeIds },
-      { gameId, teamId: game.awayTeamId, playerIds: awayIds },
-    ])
-  }
-
-  const getPlayerName = (playerId: string) => {
-    const p = players.find((x) => x.id === playerId)
-    return p ? `${p.firstName} ${p.lastName}` : playerId
-  }
-
-  const openCreateMatchDay = () => {
-    setCreatingMatchDay(true)
-    setEditingMatchDay(null)
-    const today = new Date().toISOString().slice(0, 10)
-    setMatchDayForm({
-      groupId: effectiveGroupIdForNewMatchDay,
-      number: nextMatchDayNumber(),
-      date: today,
-    })
-  }
-
-  const openEditMatchDay = (md: MatchDay) => {
-    setEditingMatchDay(md)
-    setCreatingMatchDay(false)
-    setMatchDayForm({
-      groupId: md.groupId,
-      number: md.number,
-      date: md.date,
-    })
   }
 
   const closeMatchDayModal = () => {
@@ -518,14 +462,6 @@ export function MatchDaysPage() {
       return g.teamIds.some((tid) => myClubTeamsInPhase.some((t) => t.id === tid))
     })
   }, [groups, divisions, selectedPhaseId, myClubTeamsInPhase])
-
-  const effectiveGroupIdForNewMatchDay = groupOptionsInPhase[0]?.id ?? ''
-  const nextMatchDayNumber = () => {
-    if (!effectiveGroupIdForNewMatchDay) return 1
-    const inGroup = matchDays.filter((m) => m.groupId === effectiveGroupIdForNewMatchDay)
-    if (inGroup.length === 0) return 1
-    return Math.max(...inGroup.map((m) => m.number)) + 1
-  }
 
   return (
     <div className="space-y-6">
@@ -860,9 +796,6 @@ export function MatchDaysPage() {
                               const canEditAv = canEditAvailability(player.id, team.id)
                               const selectedTeamId = getSelectedTeamForMatchDay(md.id, player.id)
                               const canEditSel = canEditGameSelection(team.id)
-                              const ourTeamsInGame = [game.homeTeamId, game.awayTeamId].filter(
-                                (tid) => teams.find((t) => t.id === tid)?.clubId && user?.clubIds?.includes(teams.find((t) => t.id === tid)!.clubId)
-                              )
                               return (
                                 <Fragment key={md.id}>
                                   <td className="border-l border-slate-100 px-2 py-1.5">

--- a/src/pages/useClubAddressForm.ts
+++ b/src/pages/useClubAddressForm.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+import type { Address } from '@/types'
+
+export type ClubAddressFormState =
+  | null
+  | { mode: 'add' }
+  | { mode: 'edit'; address: Address }
+
+export function useClubAddressFormState() {
+  return useState<ClubAddressFormState>(null)
+}


### PR DESCRIPTION
## Summary
- **Reusable ClubDetailView** for club info + addresses (used by My Club and global admin club page)
- **My Club page** (`/mon-club`) for club admins; read-only for captains/players with a club
- **Global admin**: club editing on full page at `/clubs/:affiliationNumber` (e.g. `/clubs/06680011`) with back button to clubs list
- **URL** uses club affiliation number instead of internal id
- **N° affiliation** editable only by global admin; club admin can edit name and addresses only
- Clubs list "Modifier" navigates to club detail; "Ajouter un club" stays in modal

## Changes
- `ClubDetailView`: shared component with `canEdit`, `canEditAffiliationNumber`, `onClubSaved`
- `ClubDetailPage`: admin view at `/clubs/:affiliationNumber`, resolves club by affiliation number
- `MyClubPage`: uses ClubDetailView, `canEditAffiliationNumber=false`
- `ClubsPage`: navigate to `/clubs/${club.affiliationNumber}`; create modal only
- AppShell: "Mon club" link for users with a club
- Build/parse fixes (MyClubPage, MatchDaysPage unused code)

Made with [Cursor](https://cursor.com)