### PR TITLE
Add club archive (soft delete)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,9 @@ jobs:
         env:
           npm_config_registry: 'https://registry.npmjs.org/'
       - name: Run D1 migrations
-        run: npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
+        run: |
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0002_club_archived.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -61,6 +61,7 @@ app.get('/data', async (c) => {
     })),
     clubs: clubsR.results.map(r => ({
       id: r.id, affiliationNumber: r.affiliation_number, displayName: r.display_name,
+      isArchived: bool(r.is_archived),
       addresses: addrByClub.get(r.id as string) ?? [],
     })),
     groups: groupsR.results.map(r => ({
@@ -183,8 +184,8 @@ app.post('/divisions/:id/move', async (c) => {
 app.post('/clubs', async (c) => {
   const d = await c.req.json()
   await c.env.DB.prepare(
-    'INSERT INTO clubs (id, affiliation_number, display_name) VALUES (?, ?, ?)'
-  ).bind(d.id, d.affiliationNumber, d.displayName).run()
+    'INSERT INTO clubs (id, affiliation_number, display_name, is_archived) VALUES (?, ?, ?, ?)'
+  ).bind(d.id, d.affiliationNumber, d.displayName, d.isArchived ? 1 : 0).run()
   // Insert addresses
   if (d.addresses?.length) {
     const stmts = d.addresses.map((a: Record<string, unknown>) =>
@@ -203,6 +204,7 @@ app.patch('/clubs/:id', async (c) => {
   const s: string[] = [], v: unknown[] = []
   if ('affiliationNumber' in p) { s.push('affiliation_number = ?'); v.push(p.affiliationNumber) }
   if ('displayName' in p) { s.push('display_name = ?'); v.push(p.displayName) }
+  if ('isArchived' in p) { s.push('is_archived = ?'); v.push(p.isArchived ? 1 : 0) }
   if (s.length) { v.push(id); await c.env.DB.prepare(`UPDATE clubs SET ${s.join(', ')} WHERE id = ?`).bind(...v).run() }
   return c.json({ ok: true })
 })

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS divisions (
 CREATE TABLE IF NOT EXISTS clubs (
   id TEXT PRIMARY KEY,
   affiliation_number TEXT NOT NULL,
-  display_name TEXT NOT NULL
+  display_name TEXT NOT NULL,
+  is_archived INTEGER NOT NULL DEFAULT 0
 );
 
 -- Club addresses (nested in Club on frontend, separate table in DB)

--- a/migrations/0002_club_archived.sql
+++ b/migrations/0002_club_archived.sql
@@ -1,0 +1,2 @@
+-- Add is_archived column to clubs (soft delete / archive)
+ALTER TABLE clubs ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "dev:full": "npm run build && npx wrangler pages dev",
-    "db:migrate:local": "wrangler d1 execute ping-pong-club-db --local --file=migrations/0001_initial.sql",
+    "db:migrate:local": "wrangler d1 execute ping-pong-club-db --local --file=migrations/0001_initial.sql && wrangler d1 execute ping-pong-club-db --local --file=migrations/0002_club_archived.sql",
     "db:seed:local": "wrangler d1 execute ping-pong-club-db --local --file=seed.sql",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/seed.sql
+++ b/seed.sql
@@ -15,15 +15,15 @@ INSERT INTO divisions (id, phase_id, display_name, rank, players_per_game) VALUE
   ('div-3', 'phase-1', 'GE3', 3, 4);
 
 -- clubs
-INSERT INTO clubs (id, affiliation_number, display_name) VALUES
-  ('club-1', '06680011', 'PPA Rixheim'),
-  ('club-2', '06680022', 'TT Mulhouse'),
-  ('club-3', '06680033', 'TT Bergheim'),
-  ('club-4', '06680044', 'AS Wittelsheim'),
-  ('club-5', '06680055', 'TT Anould'),
-  ('club-6', '06680066', 'TT Staffelfelden'),
-  ('club-7', '06680077', 'TT Bitschwiller'),
-  ('club-8', '06680088', 'TT Cernay');
+INSERT INTO clubs (id, affiliation_number, display_name, is_archived) VALUES
+  ('club-1', '06680011', 'PPA Rixheim', 0),
+  ('club-2', '06680022', 'TT Mulhouse', 0),
+  ('club-3', '06680033', 'TT Bergheim', 0),
+  ('club-4', '06680044', 'AS Wittelsheim', 0),
+  ('club-5', '06680055', 'TT Anould', 0),
+  ('club-6', '06680066', 'TT Staffelfelden', 0),
+  ('club-7', '06680077', 'TT Bitschwiller', 0),
+  ('club-8', '06680088', 'TT Cernay', 0);
 
 -- club_addresses
 INSERT INTO club_addresses (id, club_id, label, street, postal_code, city, is_default) VALUES

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -67,6 +67,7 @@ function api(path: string, options?: RequestInit) {
 interface DataContextValue extends Omit<DataState, 'users'> {
   updateDivision: (id: string, patch: Partial<Division>) => void
   updateClub: (id: string, patch: Partial<Club>) => void
+  archiveClub: (id: string) => void
   addClubAddress: (clubId: string, data: Omit<Address, 'id'>) => Address
   updateClubAddress: (clubId: string, addressId: string, patch: Partial<Address>) => void
   deleteClubAddress: (clubId: string, addressId: string) => void
@@ -266,6 +267,11 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     setClubs((prev) => [...prev, club])
     if (persist) api('/clubs', { method: 'POST', body: JSON.stringify(club) })
     return club
+  }, [persist])
+
+  const archiveClub = useCallback((id: string) => {
+    setClubs((prev) => prev.map((c) => (c.id === id ? { ...c, isArchived: true } : c)))
+    if (persist) api(`/clubs/${id}`, { method: 'PATCH', body: JSON.stringify({ isArchived: true }) })
   }, [persist])
 
   const addClubAddress = useCallback((clubId: string, data: Omit<Address, 'id'>) => {
@@ -563,6 +569,7 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       games,
       updateDivision,
       updateClub,
+      archiveClub,
       addClubAddress,
       updateClubAddress,
       deleteClubAddress,
@@ -595,7 +602,7 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     [
       divisions, clubs, seasons, phases, groups, teams, players,
       matchDays, games,
-      updateDivision, updateClub, addClubAddress, updateClubAddress, deleteClubAddress,
+      updateDivision, updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
       updateSeason, updatePhase, updateGroup, updateTeam,
       addClub, addSeason, addPhase, addDivision, addGroup, addTeam,
       moveDivisionUp, moveDivisionDown,

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -10,22 +10,24 @@ export const mockClubs: Club[] = [
     id: 'club-1',
     affiliationNumber: '06680011',
     displayName: 'PPA Rixheim',
+    isArchived: false,
     addresses,
   },
   {
     id: 'club-2',
     affiliationNumber: '06680022',
     displayName: 'TT Mulhouse',
+    isArchived: false,
     addresses: [
       { id: 'addr-3', label: 'Salle Omnisports', street: '1 place de la République', postalCode: '68100', city: 'Mulhouse', isDefault: true },
     ],
   },
-  { id: 'club-3', affiliationNumber: '06680033', displayName: 'TT Bergheim', addresses: [{ id: 'addr-4', label: 'Gymnase', street: '1 rue du Stade', postalCode: '68750', city: 'Bergheim', isDefault: true }] },
-  { id: 'club-4', affiliationNumber: '06680044', displayName: 'AS Wittelsheim', addresses: [{ id: 'addr-5', label: 'Salle', street: '2 ave des Sports', postalCode: '68270', city: 'Wittelsheim', isDefault: true }] },
-  { id: 'club-5', affiliationNumber: '06680055', displayName: 'TT Anould', addresses: [{ id: 'addr-6', label: 'Gymnase', street: '3 rue Principale', postalCode: '67130', city: 'Anould', isDefault: true }] },
-  { id: 'club-6', affiliationNumber: '06680066', displayName: 'TT Staffelfelden', addresses: [{ id: 'addr-7', label: 'Salle', street: '4 place du Jeu', postalCode: '68850', city: 'Staffelfelden', isDefault: true }] },
-  { id: 'club-7', affiliationNumber: '06680077', displayName: 'TT Bitschwiller', addresses: [{ id: 'addr-8', label: 'Gymnase', street: '5 rue du Sport', postalCode: '68220', city: 'Bitschwiller', isDefault: true }] },
-  { id: 'club-8', affiliationNumber: '06680088', displayName: 'TT Cernay', addresses: [{ id: 'addr-9', label: 'Salle', street: '6 rue des Lilas', postalCode: '68700', city: 'Cernay', isDefault: true }] },
+  { id: 'club-3', affiliationNumber: '06680033', displayName: 'TT Bergheim', isArchived: false, addresses: [{ id: 'addr-4', label: 'Gymnase', street: '1 rue du Stade', postalCode: '68750', city: 'Bergheim', isDefault: true }] },
+  { id: 'club-4', affiliationNumber: '06680044', displayName: 'AS Wittelsheim', isArchived: false, addresses: [{ id: 'addr-5', label: 'Salle', street: '2 ave des Sports', postalCode: '68270', city: 'Wittelsheim', isDefault: true }] },
+  { id: 'club-5', affiliationNumber: '06680055', displayName: 'TT Anould', isArchived: false, addresses: [{ id: 'addr-6', label: 'Gymnase', street: '3 rue Principale', postalCode: '67130', city: 'Anould', isDefault: true }] },
+  { id: 'club-6', affiliationNumber: '06680066', displayName: 'TT Staffelfelden', isArchived: false, addresses: [{ id: 'addr-7', label: 'Salle', street: '4 place du Jeu', postalCode: '68850', city: 'Staffelfelden', isDefault: true }] },
+  { id: 'club-7', affiliationNumber: '06680077', displayName: 'TT Bitschwiller', isArchived: false, addresses: [{ id: 'addr-8', label: 'Gymnase', street: '5 rue du Sport', postalCode: '68220', city: 'Bitschwiller', isDefault: true }] },
+  { id: 'club-8', affiliationNumber: '06680088', displayName: 'TT Cernay', isArchived: false, addresses: [{ id: 'addr-9', label: 'Salle', street: '6 rue des Lilas', postalCode: '68700', city: 'Cernay', isDefault: true }] },
 ]
 
 export const mockSeasons: Season[] = [

--- a/src/pages/admin/ClubDetailPage.tsx
+++ b/src/pages/admin/ClubDetailPage.tsx
@@ -5,7 +5,7 @@ import { ClubDetailView } from '@/components/ClubDetailView'
 export function ClubDetailPage() {
   const { affiliationNumber } = useParams<{ affiliationNumber: string }>()
   const navigate = useNavigate()
-  const { clubs } = useAppData()
+  const { clubs, archiveClub } = useAppData()
   const club =
     affiliationNumber != null
       ? clubs.find((c) => c.affiliationNumber === affiliationNumber) ?? null
@@ -22,6 +22,13 @@ export function ClubDetailPage() {
     )
   }
 
+  const handleArchive = () => {
+    if (window.confirm(`Archiver le club "${club.displayName}" ? Il ne sera plus visible dans la liste active.`)) {
+      archiveClub(club.id)
+      navigate('/clubs')
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center gap-3">
@@ -31,17 +38,39 @@ export function ClubDetailPage() {
         >
           ← Retour à la liste des clubs
         </Link>
-        <h1 className="font-display text-2xl font-semibold text-slate-800">{club.displayName}</h1>
+        <h1 className="font-display text-2xl font-semibold text-slate-800">
+          {club.displayName}
+          {club.isArchived && (
+            <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-sm font-normal text-slate-600">
+              Archivé
+            </span>
+          )}
+        </h1>
       </div>
       <ClubDetailView
         club={club}
-        canEdit
+        canEdit={!club.isArchived}
         canEditAffiliationNumber
         onClubSaved={({ affiliationNumber: newNum }) =>
           navigate(`/clubs/${encodeURIComponent(newNum)}`, { replace: true })
         }
         idPrefix="admin-club"
       />
+      {!club.isArchived && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+          <h2 className="text-sm font-medium text-red-800">Zone dangereuse</h2>
+          <p className="mt-1 text-sm text-red-700">
+            Archiver ce club le masquera de la liste active. Cette action est réversible.
+          </p>
+          <button
+            type="button"
+            onClick={handleArchive}
+            className="mt-3 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+          >
+            Archiver ce club
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/admin/ClubsPage.tsx
+++ b/src/pages/admin/ClubsPage.tsx
@@ -5,9 +5,14 @@ import { useAppData } from '@/contexts/DataContext'
 
 export function ClubsPage() {
   const navigate = useNavigate()
-  const { clubs, addClub } = useAppData()
+  const { clubs, addClub, archiveClub } = useAppData()
   const [creating, setCreating] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
   const [form, setForm] = useState({ affiliationNumber: '', displayName: '' })
+
+  const activeClubs = clubs.filter((c) => !c.isArchived)
+  const archivedClubs = clubs.filter((c) => c.isArchived)
+  const visibleClubs = showArchived ? clubs : activeClubs
 
   const openEdit = (club: Club) => {
     navigate(`/clubs/${club.affiliationNumber}`)
@@ -20,8 +25,14 @@ export function ClubsPage() {
 
   const handleSave = () => {
     if (creating) {
-      addClub({ ...form, addresses: [] })
+      addClub({ ...form, isArchived: false, addresses: [] })
       setCreating(false)
+    }
+  }
+
+  const handleArchive = (club: Club) => {
+    if (window.confirm(`Archiver le club "${club.displayName}" ? Il ne sera plus visible dans la liste active.`)) {
+      archiveClub(club.id)
     }
   }
 
@@ -41,6 +52,19 @@ export function ClubsPage() {
           Ajouter un club
         </button>
       </div>
+      {archivedClubs.length > 0 && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="rounded border-slate-300"
+          />
+          <span className="text-sm text-slate-600">
+            Afficher les clubs archivés ({archivedClubs.length})
+          </span>
+        </label>
+      )}
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
         <table className="min-w-full divide-y divide-slate-200">
           <thead className="bg-slate-50">
@@ -60,16 +84,23 @@ export function ClubsPage() {
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 bg-white">
-            {clubs.map((club) => (
-              <tr key={club.id} className="hover:bg-slate-50/50">
+            {visibleClubs.map((club) => (
+              <tr key={club.id} className={`hover:bg-slate-50/50 ${club.isArchived ? 'opacity-50' : ''}`}>
                 <td className="px-4 py-3 text-sm text-slate-900 font-mono">
                   {club.affiliationNumber}
                 </td>
-                <td className="px-4 py-3 text-sm font-medium text-slate-900">{club.displayName}</td>
+                <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                  {club.displayName}
+                  {club.isArchived && (
+                    <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600">
+                      Archivé
+                    </span>
+                  )}
+                </td>
                 <td className="px-4 py-3 text-sm text-slate-600">
                   {(club.addresses ?? []).map((a) => a.label).join(', ') || '—'}
                 </td>
-                <td className="px-4 py-3 text-right">
+                <td className="px-4 py-3 text-right space-x-3">
                   <button
                     type="button"
                     onClick={() => openEdit(club)}
@@ -77,6 +108,15 @@ export function ClubsPage() {
                   >
                     Modifier
                   </button>
+                  {!club.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleArchive(club)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Archiver
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export interface Club {
   id: string
   affiliationNumber: string
   displayName: string
+  isArchived: boolean
   addresses: Address[]
 }
 


### PR DESCRIPTION
## Summary
- Add `isArchived` field to clubs (D1 migration + type + API + mock data)
- Archive button on clubs list and detail page with confirmation dialog
- Archived clubs hidden by default, toggle to show them
- Archived clubs shown read-only in detail view with "Archivé" badge
- "Zone dangereuse" section on detail page for archive action

Closes #14

## Test plan
- [ ] Archive a club from the list → confirm it disappears, toggle shows it grayed out
- [ ] Archive a club from the detail page → redirects to list
- [ ] Toggle "Afficher les clubs archivés" shows/hides archived clubs
- [ ] Archived club detail page is read-only
- [ ] Unit tests pass (`npm run test:run`)
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)