### PR TITLE
Improve burned/selection column readability

### DIFF
--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -892,7 +892,7 @@ export function MatchDaysPage() {
                                           setPlayerSelectedForMatchDay(md.id, player.id, v)
                                         }
                                         optionIds={orderedTeamOptionIds(team.id, player.id, md.id)}
-                                        getLabel={getTeamLabel}
+                                        getLabel={getTeamSelectLabel}
                                         getColor={getTeamColor}
                                       />
                                     ) : (


### PR DESCRIPTION
## Summary
- **Burned column**: shows "Equipe N" with the team's color dot instead of truncated "PPA Rix..."
- **Selection dropdown**: shows "Eq. N" so the team number is immediately visible

Closes #36

## Test plan
- [ ] Burned column shows "Equipe 1", "Equipe 2" etc. with colored dot
- [ ] Selection dropdown shows "Eq. 1", "Eq. 2" etc. with colored dot
- [ ] Non-editable selection text also shows short format
- [ ] "Other players" section uses same format

🤖 Generated with [Claude Code](https://claude.com/claude-code)