### PR TITLE
Fix deploy: remove redundant 0002 migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,7 @@ jobs:
         env:
           npm_config_registry: 'https://registry.npmjs.org/'
       - name: Run D1 migrations
-        run: |
-          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
-          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0002_club_archived.sql
+        run: npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "dev:full": "npm run build && npx wrangler pages dev",
-    "db:migrate:local": "wrangler d1 execute ping-pong-club-db --local --file=migrations/0001_initial.sql && wrangler d1 execute ping-pong-club-db --local --file=migrations/0002_club_archived.sql",
+    "db:migrate:local": "wrangler d1 execute ping-pong-club-db --local --file=migrations/0001_initial.sql",
     "db:seed:local": "wrangler d1 execute ping-pong-club-db --local --file=seed.sql",
     "build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Remove `0002_club_archived.sql` from deploy workflow and `db:migrate:local` — it's redundant since `0001_initial.sql` already includes `is_archived`
- This was causing deploy failures (`duplicate column name: is_archived`)

## Test plan
- [ ] Deploy workflow succeeds after merge

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)