### PR TITLE
Add archive/delete support for teams

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,9 @@ jobs:
         env:
           npm_config_registry: 'https://registry.npmjs.org/'
       - name: Run D1 migrations
-        run: npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
+        run: |
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0003_team_archived.sql || true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -79,6 +79,7 @@ app.get('/data', async (c) => {
       id: r.id, clubId: r.club_id, phaseId: r.phase_id, number: r.number,
       divisionId: r.division_id, groupId: r.group_id, gameLocationId: r.game_location_id,
       defaultDay: r.default_day, defaultTime: r.default_time, captainId: r.captain_id,
+      isArchived: bool(r.is_archived),
       playerIds: jsonParse(r.player_ids),
       ...(r.roster_initial_points ? { rosterInitialPoints: jsonParse(r.roster_initial_points) } : {}),
       ...(r.color ? { color: r.color } : {}),
@@ -303,13 +304,13 @@ app.patch('/players/:id', async (c) => {
 app.post('/teams', async (c) => {
   const d = await c.req.json()
   await c.env.DB.prepare(
-    `INSERT INTO teams (id, club_id, phase_id, number, division_id, group_id, game_location_id, default_day, default_time, captain_id, player_ids, roster_initial_points, color, whatsapp_link)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO teams (id, club_id, phase_id, number, division_id, group_id, game_location_id, default_day, default_time, captain_id, player_ids, roster_initial_points, color, whatsapp_link, is_archived)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).bind(
     d.id, d.clubId, d.phaseId, d.number, d.divisionId, d.groupId,
     d.gameLocationId, d.defaultDay, d.defaultTime, d.captainId ?? '',
     jsonStr(d.playerIds ?? []), d.rosterInitialPoints ? jsonStr(d.rosterInitialPoints) : null,
-    d.color ?? null, d.whatsappLink ?? null,
+    d.color ?? null, d.whatsappLink ?? null, d.isArchived ? 1 : 0,
   ).run()
   return c.json({ ok: true })
 })
@@ -331,7 +332,35 @@ app.patch('/teams/:id', async (c) => {
   if ('rosterInitialPoints' in p) { s.push('roster_initial_points = ?'); v.push(p.rosterInitialPoints ? jsonStr(p.rosterInitialPoints) : null) }
   if ('color' in p) { s.push('color = ?'); v.push(p.color ?? null) }
   if ('whatsappLink' in p) { s.push('whatsapp_link = ?'); v.push(p.whatsappLink ?? null) }
+  if ('isArchived' in p) { s.push('is_archived = ?'); v.push(p.isArchived ? 1 : 0) }
   if (s.length) { v.push(id); await c.env.DB.prepare(`UPDATE teams SET ${s.join(', ')} WHERE id = ?`).bind(...v).run() }
+  return c.json({ ok: true })
+})
+
+// Delete team (archived only) — removes from group teamIds, cascades availabilities/selections
+app.delete('/teams/:id', async (c) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  // Remove team from group's team_ids
+  const groupsR = await db.prepare('SELECT id, team_ids FROM groups_tbl').all()
+  for (const g of groupsR.results) {
+    const teamIds: string[] = jsonParse(g.team_ids) as string[]
+    if (teamIds.includes(id)) {
+      await db.prepare('UPDATE groups_tbl SET team_ids = ? WHERE id = ?')
+        .bind(jsonStr(teamIds.filter(t => t !== id)), g.id).run()
+    }
+  }
+  // Delete related game availabilities and selections for games involving this team
+  const gamesR = await db.prepare('SELECT id FROM games WHERE home_team_id = ? OR away_team_id = ?').bind(id, id).all()
+  const gameIds = gamesR.results.map(r => r.id as string)
+  if (gameIds.length > 0) {
+    for (const gid of gameIds) {
+      await db.prepare('DELETE FROM game_availabilities WHERE game_id = ?').bind(gid).run()
+      await db.prepare('DELETE FROM game_selections WHERE game_id = ?').bind(gid).run()
+    }
+    await db.prepare('DELETE FROM games WHERE home_team_id = ? OR away_team_id = ?').bind(id, id).run()
+  }
+  await db.prepare('DELETE FROM teams WHERE id = ?').bind(id).run()
   return c.json({ ok: true })
 })
 

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -82,7 +82,8 @@ CREATE TABLE IF NOT EXISTS teams (
   player_ids TEXT NOT NULL DEFAULT '[]',
   roster_initial_points TEXT,
   color TEXT,
-  whatsapp_link TEXT
+  whatsapp_link TEXT,
+  is_archived INTEGER NOT NULL DEFAULT 0
 );
 
 -- Match days

--- a/migrations/0003_team_archived.sql
+++ b/migrations/0003_team_archived.sql
@@ -1,0 +1,2 @@
+-- Add is_archived column to teams (soft delete / archive)
+ALTER TABLE teams ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0;

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -75,6 +75,8 @@ interface DataContextValue extends Omit<DataState, 'users'> {
   updatePhase: (id: string, patch: Partial<Phase>) => void
   updateGroup: (id: string, patch: Partial<Group>) => void
   updateTeam: (id: string, patch: Partial<Team>) => void
+  archiveTeam: (id: string) => void
+  deleteTeam: (id: string) => void
   addClub: (data: Omit<Club, 'id'>) => Club
   addSeason: (data: Omit<Season, 'id'>) => Season
   addPhase: (data: Omit<Phase, 'id'>) => Phase
@@ -417,6 +419,35 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     return team
   }, [persist])
 
+  const archiveTeam = useCallback((id: string) => {
+    setTeams((prev) => prev.map((t) => (t.id === id ? { ...t, isArchived: true } : t)))
+    if (persist) api(`/teams/${id}`, { method: 'PATCH', body: JSON.stringify({ isArchived: true }) })
+  }, [persist])
+
+  const deleteTeam = useCallback((id: string) => {
+    const team = teams.find((t) => t.id === id)
+    // Remove team from group teamIds
+    if (team) {
+      const group = groups.find((g) => g.id === team.groupId)
+      if (group) {
+        setGroups((prev) =>
+          prev.map((g) =>
+            g.id === group.id ? { ...g, teamIds: g.teamIds.filter((tid) => tid !== id) } : g
+          )
+        )
+      }
+    }
+    // Remove games involving this team + their availabilities/selections
+    const teamGameIds = games.filter((g) => g.homeTeamId === id || g.awayTeamId === id).map((g) => g.id)
+    if (teamGameIds.length > 0) {
+      setGames((prev) => prev.filter((g) => !teamGameIds.includes(g.id)))
+      setGameAvailabilities((prev) => prev.filter((a) => !teamGameIds.includes(a.gameId)))
+      setGameSelections((prev) => prev.filter((s) => !teamGameIds.includes(s.gameId)))
+    }
+    setTeams((prev) => prev.filter((t) => t.id !== id))
+    if (persist) api(`/teams/${id}`, { method: 'DELETE' })
+  }, [persist, teams, groups, games])
+
   // --- Players ---
   const updatePlayer = useCallback((id: string, patch: Partial<Player>) => {
     setPlayers((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)))
@@ -577,6 +608,8 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       updatePhase,
       updateGroup,
       updateTeam,
+      archiveTeam,
+      deleteTeam,
       addClub,
       addSeason,
       addPhase,
@@ -603,7 +636,7 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       divisions, clubs, seasons, phases, groups, teams, players,
       matchDays, games,
       updateDivision, updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
-      updateSeason, updatePhase, updateGroup, updateTeam,
+      updateSeason, updatePhase, updateGroup, updateTeam, archiveTeam, deleteTeam,
       addClub, addSeason, addPhase, addDivision, addGroup, addTeam,
       moveDivisionUp, moveDivisionDown,
       updatePlayer, addPlayer,

--- a/src/lib/brulage.spec.ts
+++ b/src/lib/brulage.spec.ts
@@ -10,6 +10,7 @@ const makeTeam = (overrides: Partial<Team> & { id: string; number: number; clubI
   defaultTime: '20h00',
   captainId: '',
   playerIds: [],
+  isArchived: false,
   ...overrides,
 })
 

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -97,6 +97,7 @@ export const mockTeams: Team[] = [
     playerIds: ['player-1', 'player-3', 'player-4'],
     rosterInitialPoints: { 'player-1': '850', 'player-3': '720', 'player-4': '680' },
     color: '#374151',
+    isArchived: false,
   },
   {
     id: 'team-2',
@@ -111,13 +112,14 @@ export const mockTeams: Team[] = [
     captainId: 'player-2',
     playerIds: ['player-2'],
     color: '#b91c1c',
+    isArchived: false,
   },
-  { id: 'team-3', clubId: 'club-3', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-7', playerIds: ['player-7', 'player-8'], color: '#15803d' },
-  { id: 'team-4', clubId: 'club-4', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-5', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-9', playerIds: ['player-9', 'player-10'], color: '#c2410c' },
-  { id: 'team-5', clubId: 'club-5', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-6', defaultDay: 'Jeudi', defaultTime: '20h00', captainId: 'player-11', playerIds: ['player-11', 'player-12'], color: '#1d4ed8' },
-  { id: 'team-6', clubId: 'club-6', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-7', defaultDay: 'Vendredi', defaultTime: '19h00', captainId: 'player-13', playerIds: ['player-13', 'player-14'], color: '#7c2d12' },
-  { id: 'team-7', clubId: 'club-7', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-8', defaultDay: 'Lundi', defaultTime: '20h00', captainId: 'player-15', playerIds: ['player-15', 'player-16'], color: '#4f46e5' },
-  { id: 'team-8', clubId: 'club-8', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-9', defaultDay: 'Mercredi', defaultTime: '20h00', captainId: 'player-17', playerIds: ['player-17', 'player-18'], color: '#0d9488' },
+  { id: 'team-3', clubId: 'club-3', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-7', playerIds: ['player-7', 'player-8'], color: '#15803d', isArchived: false },
+  { id: 'team-4', clubId: 'club-4', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-5', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-9', playerIds: ['player-9', 'player-10'], color: '#c2410c', isArchived: false },
+  { id: 'team-5', clubId: 'club-5', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-6', defaultDay: 'Jeudi', defaultTime: '20h00', captainId: 'player-11', playerIds: ['player-11', 'player-12'], color: '#1d4ed8', isArchived: false },
+  { id: 'team-6', clubId: 'club-6', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-7', defaultDay: 'Vendredi', defaultTime: '19h00', captainId: 'player-13', playerIds: ['player-13', 'player-14'], color: '#7c2d12', isArchived: false },
+  { id: 'team-7', clubId: 'club-7', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-8', defaultDay: 'Lundi', defaultTime: '20h00', captainId: 'player-15', playerIds: ['player-15', 'player-16'], color: '#4f46e5', isArchived: false },
+  { id: 'team-8', clubId: 'club-8', phaseId: 'phase-1', number: 1, divisionId: 'div-1', groupId: 'group-1', gameLocationId: 'addr-9', defaultDay: 'Mercredi', defaultTime: '20h00', captainId: 'player-17', playerIds: ['player-17', 'player-18'], color: '#0d9488', isArchived: false },
   {
     id: 'team-9',
     clubId: 'club-1',
@@ -132,11 +134,12 @@ export const mockTeams: Team[] = [
     playerIds: ['player-6', 'player-19'],
     rosterInitialPoints: { 'player-6': '920', 'player-19': '650' },
     color: '#65a30d',
+    isArchived: false,
   },
   // GE2 group-2 opponents
-  { id: 'team-10', clubId: 'club-2', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-3', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-2', playerIds: ['player-2'], color: '#dc2626' },
-  { id: 'team-11', clubId: 'club-3', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-8', playerIds: ['player-8'], color: '#059669' },
-  { id: 'team-12', clubId: 'club-4', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-5', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-10', playerIds: ['player-10'], color: '#ea580c' },
+  { id: 'team-10', clubId: 'club-2', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-3', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-2', playerIds: ['player-2'], color: '#dc2626', isArchived: false },
+  { id: 'team-11', clubId: 'club-3', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-8', playerIds: ['player-8'], color: '#059669', isArchived: false },
+  { id: 'team-12', clubId: 'club-4', phaseId: 'phase-1', number: 2, divisionId: 'div-2', groupId: 'group-2', gameLocationId: 'addr-5', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-10', playerIds: ['player-10'], color: '#ea580c', isArchived: false },
   // GE3 group-3: PPA Rixheim 3 + 3 opponents
   {
     id: 'team-13',
@@ -152,10 +155,11 @@ export const mockTeams: Team[] = [
     playerIds: ['player-20', 'player-21', 'player-22'],
     rosterInitialPoints: { 'player-20': '580', 'player-21': '540', 'player-22': '510' },
     color: '#0891b2',
+    isArchived: false,
   },
-  { id: 'team-14', clubId: 'club-5', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-6', defaultDay: 'Jeudi', defaultTime: '20h00', captainId: 'player-12', playerIds: ['player-12'], color: '#2563eb' },
-  { id: 'team-15', clubId: 'club-6', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-7', defaultDay: 'Vendredi', defaultTime: '19h00', captainId: 'player-14', playerIds: ['player-14'], color: '#92400e' },
-  { id: 'team-16', clubId: 'club-7', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-8', defaultDay: 'Lundi', defaultTime: '20h00', captainId: 'player-16', playerIds: ['player-16'], color: '#6366f1' },
+  { id: 'team-14', clubId: 'club-5', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-6', defaultDay: 'Jeudi', defaultTime: '20h00', captainId: 'player-12', playerIds: ['player-12'], color: '#2563eb', isArchived: false },
+  { id: 'team-15', clubId: 'club-6', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-7', defaultDay: 'Vendredi', defaultTime: '19h00', captainId: 'player-14', playerIds: ['player-14'], color: '#92400e', isArchived: false },
+  { id: 'team-16', clubId: 'club-7', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-8', defaultDay: 'Lundi', defaultTime: '20h00', captainId: 'player-16', playerIds: ['player-16'], color: '#6366f1', isArchived: false },
   // GE3 group-3: PPA Rixheim 4 + 3 opponents (same group as PPA Rixheim 3)
   {
     id: 'team-17',
@@ -171,10 +175,11 @@ export const mockTeams: Team[] = [
     playerIds: ['player-23', 'player-24', 'player-25'],
     rosterInitialPoints: { 'player-23': '500', 'player-24': '480', 'player-25': '450' },
     color: '#be185d',
+    isArchived: false,
   },
-  { id: 'team-18', clubId: 'club-2', phaseId: 'phase-1', number: 3, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-3', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-2', playerIds: ['player-2'], color: '#e11d48' },
-  { id: 'team-19', clubId: 'club-3', phaseId: 'phase-1', number: 3, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-7', playerIds: ['player-7'], color: '#16a34a' },
-  { id: 'team-20', clubId: 'club-8', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-9', defaultDay: 'Mercredi', defaultTime: '20h00', captainId: 'player-18', playerIds: ['player-18'], color: '#0f766e' },
+  { id: 'team-18', clubId: 'club-2', phaseId: 'phase-1', number: 3, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-3', defaultDay: 'Mercredi', defaultTime: '19h30', captainId: 'player-2', playerIds: ['player-2'], color: '#e11d48', isArchived: false },
+  { id: 'team-19', clubId: 'club-3', phaseId: 'phase-1', number: 3, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-4', defaultDay: 'Mardi', defaultTime: '20h00', captainId: 'player-7', playerIds: ['player-7'], color: '#16a34a', isArchived: false },
+  { id: 'team-20', clubId: 'club-8', phaseId: 'phase-1', number: 2, divisionId: 'div-3', groupId: 'group-3', gameLocationId: 'addr-9', defaultDay: 'Mercredi', defaultTime: '20h00', captainId: 'player-18', playerIds: ['player-18'], color: '#0f766e', isArchived: false },
 ]
 
 export const mockMatchDays: MatchDay[] = [

--- a/src/pages/admin/TeamsPage.tsx
+++ b/src/pages/admin/TeamsPage.tsx
@@ -15,17 +15,27 @@ export function TeamsPage() {
     updateTeam,
     addTeam,
     updateGroup,
+    archiveTeam,
+    deleteTeam,
   } = useAppData()
 
   const isClubAdmin = user?.role === 'club_admin'
+  const isAdmin = user?.role === 'general_admin' || isClubAdmin
   const hasClubScope = (user?.role === 'club_admin' || user?.role === 'captain' || user?.role === 'player') && (user?.clubIds?.length ?? 0) > 0
 
-  const teams = useMemo(() => {
+  const [showArchived, setShowArchived] = useState(false)
+
+  const allVisibleTeams = useMemo(() => {
+    let t = allTeams
     if (hasClubScope && user?.clubIds?.length) {
-      return allTeams.filter((t) => user.clubIds.includes(t.clubId))
+      t = t.filter((team) => user.clubIds.includes(team.clubId))
     }
-    return allTeams
+    return t
   }, [allTeams, hasClubScope, user?.clubIds])
+
+  const activeTeams = useMemo(() => allVisibleTeams.filter((t) => !t.isArchived), [allVisibleTeams])
+  const archivedTeams = useMemo(() => allVisibleTeams.filter((t) => t.isArchived), [allVisibleTeams])
+  const teams = showArchived ? allVisibleTeams : activeTeams
 
   const clubsForSelect =
     hasClubScope && user?.clubIds?.length
@@ -177,6 +187,7 @@ export function TeamsPage() {
       captainId: form.captainId,
       playerIds: form.playerIds,
       rosterInitialPoints: buildRosterInitialPoints(),
+      isArchived: false,
     })
     const group = groups.find((g) => g.id === form.groupId)
     if (group) {
@@ -185,11 +196,23 @@ export function TeamsPage() {
     closeModal()
   }
 
+  const handleArchive = (team: Team) => {
+    if (window.confirm(`Archiver l'équipe "${getClubName(team.clubId)} ${team.number}" ? Elle ne sera plus visible dans la liste active.`)) {
+      archiveTeam(team.id)
+    }
+  }
+
+  const handleDelete = (team: Team) => {
+    if (window.confirm(`Supprimer définitivement l'équipe "${getClubName(team.clubId)} ${team.number}" ? Les matchs, disponibilités et compositions associés seront également supprimés. Cette action est irréversible.`)) {
+      deleteTeam(team.id)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="font-display text-2xl font-semibold text-slate-800">Équipes</h1>
-        {(user?.role === 'general_admin' || isClubAdmin) && (
+        {isAdmin && (
           <button
             type="button"
             onClick={openCreate}
@@ -199,6 +222,19 @@ export function TeamsPage() {
           </button>
         )}
       </div>
+      {archivedTeams.length > 0 && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="rounded border-slate-300"
+          />
+          <span className="text-sm text-slate-600">
+            Afficher les équipes archivées ({archivedTeams.length})
+          </span>
+        </label>
+      )}
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-200">
           <thead className="bg-slate-50">
@@ -221,15 +257,24 @@ export function TeamsPage() {
               <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-slate-700">
                 Capitaine
               </th>
-              <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-slate-700">
-                Actions
-              </th>
+              {isAdmin && (
+                <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-slate-700">
+                  Actions
+                </th>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 bg-white">
             {teams.map((team) => (
-              <tr key={team.id} className="hover:bg-slate-50/50">
-                <td className="px-4 py-3 text-sm font-medium text-slate-900">{getClubName(team.clubId)}</td>
+              <tr key={team.id} className={`hover:bg-slate-50/50 ${team.isArchived ? 'opacity-50' : ''}`}>
+                <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                  {getClubName(team.clubId)}
+                  {team.isArchived && (
+                    <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600">
+                      Archivé
+                    </span>
+                  )}
+                </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{team.number}</td>
                 <td className="px-4 py-3 text-sm text-slate-600">{getPhaseName(team.phaseId)}</td>
                 <td className="px-4 py-3 text-sm text-slate-600">{getDivisionName(team.divisionId)}</td>
@@ -237,17 +282,37 @@ export function TeamsPage() {
                   {team.defaultDay} {team.defaultTime}
                 </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{getCaptainName(team.captainId)}</td>
-                <td className="px-4 py-3 text-right">
-                  {(user?.role === 'general_admin' || isClubAdmin) && (
-                    <button
-                      type="button"
-                      onClick={() => openEdit(team)}
-                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                    >
-                      Modifier
-                    </button>
-                  )}
-                </td>
+                {isAdmin && (
+                  <td className="px-4 py-3 text-right space-x-3">
+                    {!team.isArchived && (
+                      <button
+                        type="button"
+                        onClick={() => openEdit(team)}
+                        className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                      >
+                        Modifier
+                      </button>
+                    )}
+                    {!team.isArchived && (
+                      <button
+                        type="button"
+                        onClick={() => handleArchive(team)}
+                        className="text-sm font-medium text-red-600 hover:text-red-800"
+                      >
+                        Archiver
+                      </button>
+                    )}
+                    {team.isArchived && (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(team)}
+                        className="text-sm font-medium text-red-600 hover:text-red-800"
+                      >
+                        Supprimer
+                      </button>
+                    )}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,7 @@ export interface Team {
   defaultDay: string
   defaultTime: string
   captainId: string
+  isArchived: boolean
   /** Roster for this team (phase). Used for availability and game selection. */
   playerIds: string[]
   /** Initial points per player at the start of the phase (Club Admin sets when defining roster). */


### PR DESCRIPTION
## Summary
- **Archive**: Teams can be archived (soft delete) — hidden by default, shown with toggle, "Archivé" badge
- **Delete**: Only archived teams can be deleted — cascades to remove from group `teamIds`, deletes related games, availabilities, and selections
- **Actions column**: Hidden for non-admin users (captains, players)
- Schema migration `0003_team_archived.sql` adds `is_archived` column

## Test plan
- [ ] Archive a team → disappears from list, toggle shows it with badge
- [ ] Delete an archived team → removed with related data
- [ ] Non-admin user sees no Actions column
- [ ] Create new team → `isArchived: false` by default
- [ ] Unit tests pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)