### PR TITLE
Show team color dot on read-only Compo cells

### DIFF
--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -967,7 +967,14 @@ export function MatchDaysPage() {
                                           getColor={getTeamColor}
                                         />
                                       ) : (
-                                        <span className="text-xs text-slate-600">
+                                        <span className="inline-flex items-center gap-1 text-xs text-slate-600">
+                                          {selectedTeamId && getTeamColor(selectedTeamId) && (
+                                            <span
+                                              className="shrink-0 w-2.5 h-2.5 rounded-full"
+                                              style={{ backgroundColor: getTeamColor(selectedTeamId) }}
+                                              aria-hidden
+                                            />
+                                          )}
                                           {selectedTeamId ? getTeamSelectLabel(selectedTeamId) : '—'}
                                         </span>
                                       )}
@@ -1270,7 +1277,14 @@ export function MatchDaysPage() {
                                   getColor={getTeamColor}
                                 />
                               ) : (
-                                <span className="text-xs text-slate-600">
+                                <span className="inline-flex items-center gap-1 text-xs text-slate-600">
+                                  {selectedTeamId && getTeamColor(selectedTeamId) && (
+                                    <span
+                                      className="shrink-0 w-2.5 h-2.5 rounded-full"
+                                      style={{ backgroundColor: getTeamColor(selectedTeamId) }}
+                                      aria-hidden
+                                    />
+                                  )}
                                   {selectedTeamId ? getTeamSelectLabel(selectedTeamId) : '—'}
                                 </span>
                               )}


### PR DESCRIPTION
## Summary
- Add colored team dot next to the label in read-only Compo cells (all 3 locations: roster with game, roster without game, other players)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)