### PR TITLE
Archive/delete for seasons

### DIFF
--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -127,6 +127,45 @@ app.patch('/seasons/:id', async (c) => {
   return c.json({ ok: true })
 })
 
+app.delete('/seasons/:id', async (c) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  // Find phases belonging to this season
+  const phasesR = await db.prepare('SELECT id FROM phases WHERE season_id = ?').bind(id).all()
+  const phaseIds = phasesR.results.map(r => r.id as string)
+  for (const phaseId of phaseIds) {
+    // Find divisions in phase
+    const divsR = await db.prepare('SELECT id FROM divisions WHERE phase_id = ?').bind(phaseId).all()
+    const divIds = divsR.results.map(r => r.id as string)
+    for (const divId of divIds) {
+      // Find groups in division
+      const grpsR = await db.prepare('SELECT id FROM groups_tbl WHERE division_id = ?').bind(divId).all()
+      const grpIds = grpsR.results.map(r => r.id as string)
+      // Delete match days in these groups
+      for (const gid of grpIds) {
+        // Delete games + availabilities + selections for match days in this group
+        const mdsR = await db.prepare('SELECT id FROM match_days WHERE group_id = ?').bind(gid).all()
+        for (const md of mdsR.results) {
+          const mdGames = await db.prepare('SELECT id FROM games WHERE match_day_id = ?').bind(md.id).all()
+          for (const g of mdGames.results) {
+            await db.prepare('DELETE FROM game_availabilities WHERE game_id = ?').bind(g.id).run()
+            await db.prepare('DELETE FROM game_selections WHERE game_id = ?').bind(g.id).run()
+          }
+          await db.prepare('DELETE FROM games WHERE match_day_id = ?').bind(md.id).run()
+        }
+        await db.prepare('DELETE FROM match_days WHERE group_id = ?').bind(gid).run()
+        await db.prepare('DELETE FROM groups_tbl WHERE id = ?').bind(gid).run()
+      }
+      // Delete teams in division
+      await db.prepare('DELETE FROM teams WHERE division_id = ?').bind(divId).run()
+      await db.prepare('DELETE FROM divisions WHERE id = ?').bind(divId).run()
+    }
+    await db.prepare('DELETE FROM phases WHERE id = ?').bind(phaseId).run()
+  }
+  await db.prepare('DELETE FROM seasons WHERE id = ?').bind(id).run()
+  return c.json({ ok: true })
+})
+
 // --- Phases ---
 app.post('/phases', async (c) => {
   const d = await c.req.json()

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -72,6 +72,8 @@ interface DataContextValue extends Omit<DataState, 'users'> {
   updateClubAddress: (clubId: string, addressId: string, patch: Partial<Address>) => void
   deleteClubAddress: (clubId: string, addressId: string) => void
   updateSeason: (id: string, patch: Partial<Season>) => void
+  archiveSeason: (id: string) => void
+  deleteSeason: (id: string) => void
   updatePhase: (id: string, patch: Partial<Phase>) => void
   updateGroup: (id: string, patch: Partial<Group>) => void
   updateTeam: (id: string, patch: Partial<Team>) => void
@@ -188,6 +190,32 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     if (persist) api('/seasons', { method: 'POST', body: JSON.stringify(season) })
     return season
   }, [persist])
+
+  const archiveSeason = useCallback((id: string) => {
+    setSeasons((prev) => prev.map((s) => (s.id === id ? { ...s, isArchived: true } : s)))
+    if (persist) api(`/seasons/${id}`, { method: 'PATCH', body: JSON.stringify({ isArchived: true }) })
+  }, [persist])
+
+  const deleteSeason = useCallback((id: string) => {
+    // Cascade: find phases → divisions → groups → teams, match days, games, avail, selections
+    const phaseIds = phases.filter((p) => p.seasonId === id).map((p) => p.id)
+    const divIds = divisions.filter((d) => phaseIds.includes(d.phaseId)).map((d) => d.id)
+    const grpIds = groups.filter((g) => divIds.includes(g.divisionId)).map((g) => g.id)
+    const teamIds = teams.filter((t) => phaseIds.includes(t.phaseId)).map((t) => t.id)
+    const mdIds = matchDays.filter((md) => grpIds.includes(md.groupId)).map((md) => md.id)
+    const gameIds = games.filter((g) => mdIds.includes(g.matchDayId)).map((g) => g.id)
+
+    setGameAvailabilities((prev) => prev.filter((a) => !gameIds.includes(a.gameId)))
+    setGameSelections((prev) => prev.filter((s) => !gameIds.includes(s.gameId)))
+    setGames((prev) => prev.filter((g) => !gameIds.includes(g.id)))
+    setMatchDays((prev) => prev.filter((md) => !mdIds.includes(md.id)))
+    setTeams((prev) => prev.filter((t) => !teamIds.includes(t.id)))
+    setGroups((prev) => prev.filter((g) => !grpIds.includes(g.id)))
+    setDivisions((prev) => prev.filter((d) => !divIds.includes(d.id)))
+    setPhases((prev) => prev.filter((p) => !phaseIds.includes(p.id)))
+    setSeasons((prev) => prev.filter((s) => s.id !== id))
+    if (persist) api(`/seasons/${id}`, { method: 'DELETE' })
+  }, [persist, phases, divisions, groups, teams, matchDays, games])
 
   // --- Phases ---
   const updatePhase = useCallback((id: string, patch: Partial<Phase>) => {
@@ -605,6 +633,8 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       updateClubAddress,
       deleteClubAddress,
       updateSeason,
+      archiveSeason,
+      deleteSeason,
       updatePhase,
       updateGroup,
       updateTeam,
@@ -636,7 +666,7 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       divisions, clubs, seasons, phases, groups, teams, players,
       matchDays, games,
       updateDivision, updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
-      updateSeason, updatePhase, updateGroup, updateTeam, archiveTeam, deleteTeam,
+      updateSeason, archiveSeason, deleteSeason, updatePhase, updateGroup, updateTeam, archiveTeam, deleteTeam,
       addClub, addSeason, addPhase, addDivision, addGroup, addTeam,
       moveDivisionUp, moveDivisionDown,
       updatePlayer, addPlayer,

--- a/src/pages/admin/SeasonsPage.tsx
+++ b/src/pages/admin/SeasonsPage.tsx
@@ -1,12 +1,17 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { Season } from '@/types'
 import { useAppData } from '@/contexts/DataContext'
 
 export function SeasonsPage() {
-  const { seasons, updateSeason, addSeason } = useAppData()
+  const { seasons: allSeasons, updateSeason, addSeason, archiveSeason, deleteSeason } = useAppData()
   const [editing, setEditing] = useState<Season | null>(null)
   const [creating, setCreating] = useState(false)
   const [form, setForm] = useState({ displayName: '', isActive: false, isArchived: false })
+  const [showArchived, setShowArchived] = useState(false)
+
+  const activeSeasons = useMemo(() => allSeasons.filter((s) => !s.isArchived), [allSeasons])
+  const archivedSeasons = useMemo(() => allSeasons.filter((s) => s.isArchived), [allSeasons])
+  const seasons = showArchived ? allSeasons : activeSeasons
 
   const openEdit = (season: Season) => {
     setEditing(season)
@@ -34,6 +39,18 @@ export function SeasonsPage() {
     }
   }
 
+  const handleArchive = (season: Season) => {
+    if (window.confirm(`Archiver la saison "${season.displayName}" ? Elle ne sera plus visible dans la liste active.`)) {
+      archiveSeason(season.id)
+    }
+  }
+
+  const handleDelete = (season: Season) => {
+    if (window.confirm(`Supprimer définitivement la saison "${season.displayName}" ? Toutes les phases, divisions, groupes, équipes, journées, matchs, disponibilités et compositions associés seront également supprimés. Cette action est irréversible.`)) {
+      deleteSeason(season.id)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -46,6 +63,19 @@ export function SeasonsPage() {
           Ajouter une saison
         </button>
       </div>
+      {archivedSeasons.length > 0 && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="rounded border-slate-300"
+          />
+          <span className="text-sm text-slate-600">
+            Afficher les saisons archivées ({archivedSeasons.length})
+          </span>
+        </label>
+      )}
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
         <table className="min-w-full divide-y divide-slate-200">
           <thead className="bg-slate-50">
@@ -63,25 +93,52 @@ export function SeasonsPage() {
           </thead>
           <tbody className="divide-y divide-slate-200 bg-white">
             {seasons.map((season) => (
-              <tr key={season.id} className="hover:bg-slate-50/50">
-                <td className="px-4 py-3 text-sm font-medium text-slate-900">{season.displayName}</td>
+              <tr key={season.id} className={`hover:bg-slate-50/50 ${season.isArchived ? 'opacity-50' : ''}`}>
+                <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                  {season.displayName}
+                  {season.isArchived && (
+                    <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600">
+                      Archivée
+                    </span>
+                  )}
+                </td>
                 <td className="px-4 py-3">
                   <span
                     className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
                       season.isActive ? 'bg-green-100 text-green-800' : 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    {season.isActive ? 'Active' : season.isArchived ? 'Archivée' : '—'}
+                    {season.isActive ? 'Active' : '—'}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(season)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    Modifier
-                  </button>
+                <td className="px-4 py-3 text-right space-x-3">
+                  {!season.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => openEdit(season)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                  )}
+                  {!season.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleArchive(season)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Archiver
+                    </button>
+                  )}
+                  {season.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(season)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Supprimer
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -122,15 +179,6 @@ export function SeasonsPage() {
                     className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
                   />
                   <span className="text-sm text-slate-700">Active</span>
-                </label>
-                <label className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={form.isArchived}
-                    onChange={(e) => setForm((f) => ({ ...f, isArchived: e.target.checked }))}
-                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="text-sm text-slate-700">Archivée</span>
                 </label>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- **Archive**: sets `isArchived = true`, hidden by default with toggle to show
- **Delete**: only allowed on archived seasons, cascades through the full hierarchy (phases → divisions → groups → teams → match days → games → availabilities → selections)
- API: new `DELETE /seasons/:id` with cascade
- DataContext: `archiveSeason` + `deleteSeason` with optimistic updates
- UI: archive/delete buttons, "Archivée" badge, opacity for archived rows, removed `isArchived` checkbox from edit modal

Closes #30

## Test plan
- [ ] Archive a season — verify it disappears from default list
- [ ] Toggle "show archived" — verify archived season appears with badge and reduced opacity
- [ ] Delete an archived season — verify cascade removes all child data
- [ ] Verify active seasons still show edit + archive buttons
- [ ] Verify archived seasons only show delete button

🤖 Generated with [Claude Code](https://claude.com/claude-code)