### PR TITLE
Ephemeral preview deployments for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,71 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+        env:
+          npm_config_registry: 'https://registry.npmjs.org/'
+      - name: Build with PR metadata
+        run: npm run build
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.sha }}
+      - name: Deploy preview to Cloudflare Pages
+        id: deploy
+        run: |
+          DEPLOY_OUTPUT=$(npx wrangler pages deploy --project-name=ping-pong-club --branch="pr-${{ github.event.pull_request.number }}" 2>&1)
+          echo "$DEPLOY_OUTPUT"
+          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -oE 'https://[^ ]+\.pages\.dev' | tail -1)
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
+            const sha = '${{ github.sha }}'.slice(0, 7);
+            const body = `🔍 **Preview deployed**\n\n` +
+              `📎 ${previewUrl}\n` +
+              `📦 Commit: \`${sha}\`\n\n` +
+              `_Updated on each push to this PR._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview deployed')
+            );
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2,6 +2,19 @@ import { Link, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useAppData } from '@/contexts/DataContext'
 
+const prNumber = __PR_NUMBER__
+const commitSha = __COMMIT_SHA__
+
+function PreviewBanner() {
+  if (!prNumber) return null
+  const shortSha = commitSha ? commitSha.slice(0, 7) : ''
+  return (
+    <div className="bg-amber-500 text-white text-xs text-center py-1 px-4 font-medium">
+      Preview — PR #{prNumber}{shortSha ? ` · ${shortSha}` : ''}
+    </div>
+  )
+}
+
 const navLinkClass = (active: boolean) =>
   `text-sm font-medium ${active ? 'text-slate-900' : 'text-slate-600 hover:text-slate-900'}`
 
@@ -23,6 +36,7 @@ export function AppShell() {
 
   return (
     <div className="min-h-screen flex flex-col bg-slate-50">
+      <PreviewBanner />
       <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6">
           <Link to="/" className="font-display text-lg font-semibold text-slate-800">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __PR_NUMBER__: string
+declare const __COMMIT_SHA__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __PR_NUMBER__: JSON.stringify(process.env.PR_NUMBER || ''),
+    __COMMIT_SHA__: JSON.stringify(process.env.COMMIT_SHA || ''),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- New `.github/workflows/preview.yml` deploys a Cloudflare Pages preview on each PR push
- Preview URL uses branch name `pr-N` (e.g. `pr-49.ping-pong-club.pages.dev`)
- PR number + commit SHA injected at build time via Vite `define`
- Amber banner in AppShell shows "Preview — PR #49 · abc1234" on preview builds
- Banner is completely tree-shaken out of production builds (empty string = dead code)
- Workflow posts/updates a single bot comment on the PR with the preview URL

Closes #50

## Test plan
- [ ] Merge this PR and open another PR — verify preview workflow runs
- [ ] Verify preview URL is posted as a comment on the PR
- [ ] Verify the amber banner shows PR number and commit SHA on the preview site
- [ ] Verify production site (main) does NOT show the banner
- [ ] Push a new commit to PR — verify comment is updated with new SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)