### PR TITLE
Clean up preview deployments on PR close

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,10 +2,41 @@ name: Preview Deploy
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install -g wrangler
+      - name: Delete preview deployment
+        run: |
+          BRANCH="pr-${{ github.event.pull_request.number }}"
+          echo "Deleting deployments for branch: $BRANCH"
+          # List and delete all deployments for this branch
+          DEPLOYMENTS=$(npx wrangler pages deployment list --project-name=ping-pong-club 2>&1 || true)
+          echo "$DEPLOYMENTS"
+          # Use the Cloudflare API directly to delete deployments by branch alias
+          PROJECT="ping-pong-club"
+          API_URL="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT/deployments"
+          DEPS=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$API_URL" | jq -r ".result[] | select(.deployment_trigger.metadata.branch == \"$BRANCH\") | .id")
+          for DEP_ID in $DEPS; do
+            echo "Deleting deployment $DEP_ID"
+            curl -s -X DELETE -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$API_URL/$DEP_ID?force=true"
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}
+
   preview:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds a `cleanup` job to the preview workflow, triggered when a PR is closed/merged
- Uses the Cloudflare API to find and delete all deployments for the `pr-N` branch
- Preview URLs will stop working after merge instead of lingering

Follow-up to #50

## Test plan
- [ ] Merge this PR — verify the cleanup job runs on close
- [ ] Check that `https://pr-51.ping-pong-club.pages.dev` stops working after cleanup
- [ ] Open a new PR — verify preview deploy still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)