### PR TITLE
Add archive/delete for divisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
           npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0003_team_archived.sql || true
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0004_division_archived.sql || true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -58,6 +58,7 @@ app.get('/data', async (c) => {
     divisions: divisionsR.results.map(r => ({
       id: r.id, phaseId: r.phase_id, displayName: r.display_name,
       rank: r.rank, playersPerGame: r.players_per_game,
+      isArchived: bool(r.is_archived),
     })),
     clubs: clubsR.results.map(r => ({
       id: r.id, affiliationNumber: r.affiliation_number, displayName: r.display_name,
@@ -240,8 +241,8 @@ app.delete('/phases/:id', async (c) => {
 app.post('/divisions', async (c) => {
   const d = await c.req.json()
   await c.env.DB.prepare(
-    'INSERT INTO divisions (id, phase_id, display_name, rank, players_per_game) VALUES (?, ?, ?, ?, ?)'
-  ).bind(d.id, d.phaseId, d.displayName, d.rank, d.playersPerGame).run()
+    'INSERT INTO divisions (id, phase_id, display_name, rank, players_per_game, is_archived) VALUES (?, ?, ?, ?, ?, ?)'
+  ).bind(d.id, d.phaseId, d.displayName, d.rank, d.playersPerGame, d.isArchived ? 1 : 0).run()
   return c.json({ ok: true })
 })
 
@@ -253,7 +254,39 @@ app.patch('/divisions/:id', async (c) => {
   if ('displayName' in p) { s.push('display_name = ?'); v.push(p.displayName) }
   if ('rank' in p) { s.push('rank = ?'); v.push(p.rank) }
   if ('playersPerGame' in p) { s.push('players_per_game = ?'); v.push(p.playersPerGame) }
+  if ('isArchived' in p) { s.push('is_archived = ?'); v.push(p.isArchived ? 1 : 0) }
   if (s.length) { v.push(id); await c.env.DB.prepare(`UPDATE divisions SET ${s.join(', ')} WHERE id = ?`).bind(...v).run() }
+  return c.json({ ok: true })
+})
+
+// Delete division (archived only) — cascades: groups → teams → match days → games → availabilities → selections
+app.delete('/divisions/:id', async (c) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  // Find groups in this division
+  const groupsR = await db.prepare('SELECT id FROM groups_tbl WHERE division_id = ?').bind(id).all()
+  const groupIds = groupsR.results.map(r => r.id as string)
+  for (const gid of groupIds) {
+    // Find match days in this group
+    const mdsR = await db.prepare('SELECT id FROM match_days WHERE group_id = ?').bind(gid).all()
+    const mdIds = mdsR.results.map(r => r.id as string)
+    for (const mdId of mdIds) {
+      // Find games in this match day
+      const gamesR = await db.prepare('SELECT id FROM games WHERE match_day_id = ?').bind(mdId).all()
+      for (const game of gamesR.results) {
+        await db.prepare('DELETE FROM game_availabilities WHERE game_id = ?').bind(game.id).run()
+        await db.prepare('DELETE FROM game_selections WHERE game_id = ?').bind(game.id).run()
+      }
+      await db.prepare('DELETE FROM games WHERE match_day_id = ?').bind(mdId).run()
+    }
+    await db.prepare('DELETE FROM match_days WHERE group_id = ?').bind(gid).run()
+    // Delete teams in this group
+    await db.prepare('DELETE FROM teams WHERE group_id = ?').bind(gid).run()
+  }
+  // Delete groups
+  await db.prepare('DELETE FROM groups_tbl WHERE division_id = ?').bind(id).run()
+  // Delete division
+  await db.prepare('DELETE FROM divisions WHERE id = ?').bind(id).run()
   return c.json({ ok: true })
 })
 

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS divisions (
   phase_id TEXT NOT NULL,
   display_name TEXT NOT NULL,
   rank INTEGER NOT NULL,
-  players_per_game INTEGER NOT NULL DEFAULT 4
+  players_per_game INTEGER NOT NULL DEFAULT 4,
+  is_archived INTEGER NOT NULL DEFAULT 0
 );
 
 -- Clubs

--- a/migrations/0004_division_archived.sql
+++ b/migrations/0004_division_archived.sql
@@ -1,0 +1,1 @@
+ALTER TABLE divisions ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0;

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -66,6 +66,8 @@ function api(path: string, options?: RequestInit) {
 
 interface DataContextValue extends Omit<DataState, 'users'> {
   updateDivision: (id: string, patch: Partial<Division>) => void
+  archiveDivision: (id: string) => void
+  deleteDivision: (id: string) => void
   updateClub: (id: string, patch: Partial<Club>) => void
   archiveClub: (id: string) => void
   addClubAddress: (clubId: string, data: Omit<Address, 'id'>) => Address
@@ -312,6 +314,29 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       )
     })
   }, [persist])
+
+  const archiveDivision = useCallback((id: string) => {
+    setDivisions((prev) => prev.map((d) => (d.id === id ? { ...d, isArchived: true } : d)))
+    if (persist) api(`/divisions/${id}`, { method: 'PATCH', body: JSON.stringify({ isArchived: true }) })
+  }, [persist])
+
+  const deleteDivision = useCallback((id: string) => {
+    // Cascade: groups → teams → match days → games → availabilities → selections
+    const divGroupIds = groups.filter((g) => g.divisionId === id).map((g) => g.id)
+    const divTeamIds = teams.filter((t) => divGroupIds.includes(t.groupId)).map((t) => t.id)
+    const divMatchDayIds = matchDays.filter((md) => divGroupIds.includes(md.groupId)).map((md) => md.id)
+    const divGameIds = games.filter((g) => divMatchDayIds.includes(g.matchDayId)).map((g) => g.id)
+
+    setGameSelections((prev) => prev.filter((s) => !divGameIds.includes(s.gameId)))
+    setGameAvailabilities((prev) => prev.filter((a) => !divGameIds.includes(a.gameId)))
+    setGames((prev) => prev.filter((g) => !divGameIds.includes(g.id)))
+    setMatchDays((prev) => prev.filter((md) => !divMatchDayIds.includes(md.id)))
+    setTeams((prev) => prev.filter((t) => !divTeamIds.includes(t.id)))
+    setGroups((prev) => prev.filter((g) => !divGroupIds.includes(g.id)))
+    setDivisions((prev) => prev.filter((d) => d.id !== id))
+
+    if (persist) api(`/divisions/${id}`, { method: 'DELETE' })
+  }, [persist, groups, teams, matchDays, games])
 
   // --- Clubs ---
   const updateClub = useCallback((id: string, patch: Partial<Club>) => {
@@ -655,6 +680,8 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       matchDays,
       games,
       updateDivision,
+      archiveDivision,
+      deleteDivision,
       updateClub,
       archiveClub,
       addClubAddress,
@@ -695,7 +722,8 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     [
       divisions, clubs, seasons, phases, groups, teams, players,
       matchDays, games,
-      updateDivision, updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
+      updateDivision, archiveDivision, deleteDivision,
+      updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
       updateSeason, archiveSeason, deleteSeason, updatePhase, archivePhase, deletePhase, updateGroup, updateTeam, archiveTeam, deleteTeam,
       addClub, addSeason, addPhase, addDivision, addGroup, addTeam,
       moveDivisionUp, moveDivisionDown,

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -39,9 +39,9 @@ export const mockPhases: Phase[] = [
 ]
 
 export const mockDivisions: Division[] = [
-  { id: 'div-1', phaseId: 'phase-1', displayName: 'GE1', rank: 1, playersPerGame: 4 },
-  { id: 'div-2', phaseId: 'phase-1', displayName: 'GE2', rank: 2, playersPerGame: 4 },
-  { id: 'div-3', phaseId: 'phase-1', displayName: 'GE3', rank: 3, playersPerGame: 4 },
+  { id: 'div-1', phaseId: 'phase-1', displayName: 'GE1', rank: 1, playersPerGame: 4, isArchived: false },
+  { id: 'div-2', phaseId: 'phase-1', displayName: 'GE2', rank: 2, playersPerGame: 4, isArchived: false },
+  { id: 'div-3', phaseId: 'phase-1', displayName: 'GE3', rank: 3, playersPerGame: 4, isArchived: false },
 ]
 
 export const mockPlayers: Player[] = [

--- a/src/pages/admin/DivisionsPage.tsx
+++ b/src/pages/admin/DivisionsPage.tsx
@@ -1,13 +1,27 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { Division } from '@/types'
 import { useAppData } from '@/contexts/DataContext'
 
 export function DivisionsPage() {
-  const { divisions, phases, updateDivision, addDivision, moveDivisionUp, moveDivisionDown } =
-    useAppData()
+  const {
+    divisions: allDivisions,
+    phases,
+    updateDivision,
+    addDivision,
+    moveDivisionUp,
+    moveDivisionDown,
+    archiveDivision,
+    deleteDivision,
+  } = useAppData()
+
+  const [showArchived, setShowArchived] = useState(false)
   const [editing, setEditing] = useState<Division | null>(null)
   const [creating, setCreating] = useState(false)
   const [form, setForm] = useState({ phaseId: '', displayName: '', rank: 1, playersPerGame: 4 })
+
+  const activeDivisions = useMemo(() => allDivisions.filter((d) => !d.isArchived), [allDivisions])
+  const archivedDivisions = useMemo(() => allDivisions.filter((d) => d.isArchived), [allDivisions])
+  const divisions = showArchived ? allDivisions : activeDivisions
 
   const getPhaseName = (phaseId: string) =>
     phases.find((p) => p.id === phaseId)?.displayName ?? phaseId
@@ -17,12 +31,14 @@ export function DivisionsPage() {
     .sort((a, b) => (a.phaseId !== b.phaseId ? a.phaseId.localeCompare(b.phaseId) : a.rank - b.rank))
 
   const getCanMoveUp = (div: Division) => {
-    const inPhase = divisions.filter((d) => d.phaseId === div.phaseId).sort((a, b) => a.rank - b.rank)
+    if (div.isArchived) return false
+    const inPhase = activeDivisions.filter((d) => d.phaseId === div.phaseId).sort((a, b) => a.rank - b.rank)
     const idx = inPhase.findIndex((d) => d.id === div.id)
     return idx > 0
   }
   const getCanMoveDown = (div: Division) => {
-    const inPhase = divisions.filter((d) => d.phaseId === div.phaseId).sort((a, b) => a.rank - b.rank)
+    if (div.isArchived) return false
+    const inPhase = activeDivisions.filter((d) => d.phaseId === div.phaseId).sort((a, b) => a.rank - b.rank)
     const idx = inPhase.findIndex((d) => d.id === div.id)
     return idx >= 0 && idx < inPhase.length - 1
   }
@@ -43,8 +59,8 @@ export function DivisionsPage() {
     setCreating(true)
     const phaseId = phases[0]?.id ?? ''
     const maxRank =
-      phaseId && divisions.filter((d) => d.phaseId === phaseId).length > 0
-        ? Math.max(...divisions.filter((d) => d.phaseId === phaseId).map((d) => d.rank)) + 1
+      phaseId && activeDivisions.filter((d) => d.phaseId === phaseId).length > 0
+        ? Math.max(...activeDivisions.filter((d) => d.phaseId === phaseId).map((d) => d.rank)) + 1
         : 1
     setForm({
       phaseId,
@@ -73,8 +89,21 @@ export function DivisionsPage() {
         displayName: form.displayName,
         rank: form.rank,
         playersPerGame: form.playersPerGame,
+        isArchived: false,
       })
       closeModal()
+    }
+  }
+
+  const handleArchive = (div: Division) => {
+    if (window.confirm(`Archiver la division "${div.displayName}" ? Elle ne sera plus visible dans la liste active.`)) {
+      archiveDivision(div.id)
+    }
+  }
+
+  const handleDelete = (div: Division) => {
+    if (window.confirm(`Supprimer définitivement la division "${div.displayName}" ? Les groupes, équipes, journées, matchs, disponibilités et compositions associés seront également supprimés. Cette action est irréversible.`)) {
+      deleteDivision(div.id)
     }
   }
 
@@ -90,6 +119,19 @@ export function DivisionsPage() {
           Ajouter une division
         </button>
       </div>
+      {archivedDivisions.length > 0 && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="rounded border-slate-300"
+          />
+          <span className="text-sm text-slate-600">
+            Afficher les divisions archivées ({archivedDivisions.length})
+          </span>
+        </label>
+      )}
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
         <table className="min-w-full divide-y divide-slate-200">
           <thead className="bg-slate-50">
@@ -113,8 +155,15 @@ export function DivisionsPage() {
           </thead>
           <tbody className="divide-y divide-slate-200 bg-white">
             {divisionsByPhase.map((div) => (
-              <tr key={div.id} className="hover:bg-slate-50/50">
-                <td className="px-4 py-3 text-sm font-medium text-slate-900">{div.displayName}</td>
+              <tr key={div.id} className={`hover:bg-slate-50/50 ${div.isArchived ? 'opacity-50' : ''}`}>
+                <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                  {div.displayName}
+                  {div.isArchived && (
+                    <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600">
+                      Archivée
+                    </span>
+                  )}
+                </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{getPhaseName(div.phaseId)}</td>
                 <td className="px-4 py-3">
                   <div className="flex items-center justify-center gap-0.5">
@@ -145,14 +194,34 @@ export function DivisionsPage() {
                   </div>
                 </td>
                 <td className="px-4 py-3 text-sm text-slate-600">{div.playersPerGame}</td>
-                <td className="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(div)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    Modifier
-                  </button>
+                <td className="px-4 py-3 text-right space-x-3">
+                  {!div.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => openEdit(div)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                  )}
+                  {!div.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleArchive(div)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Archiver
+                    </button>
+                  )}
+                  {div.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(div)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Supprimer
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -182,7 +251,7 @@ export function DivisionsPage() {
                     value={form.phaseId}
                     onChange={(e) => {
                       const phaseId = e.target.value
-                      const inPhase = divisions.filter((d) => d.phaseId === phaseId)
+                      const inPhase = activeDivisions.filter((d) => d.phaseId === phaseId)
                       const maxRank = inPhase.length > 0 ? Math.max(...inPhase.map((d) => d.rank)) + 1 : 1
                       setForm((f) => ({ ...f, phaseId, rank: maxRank }))
                     }}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export interface Division {
   displayName: string
   rank: number
   playersPerGame: number
+  isArchived: boolean
 }
 
 export interface Group {


### PR DESCRIPTION
## Summary
- Add `isArchived` field to Division type, DB schema (migration 0004), and API
- Add `archiveDivision` and `deleteDivision` to DataContext with full cascade (groups, teams, match days, games, availabilities, selections)
- Add archive/delete UI to DivisionsPage following the same pattern as TeamsPage (toggle checkbox, archive button on active, delete button on archived, opacity + badge for archived rows)
- Update deploy workflow with new migration, mock data with `isArchived: false`

Closes #32

## Test plan
- [x] `npm run build` passes (no TypeScript errors)
- [x] `npm run test:run` passes (31 tests)
- [ ] Manual: archive a division, verify it appears dimmed with "Archivée" badge
- [ ] Manual: toggle "show archived" checkbox, verify archived divisions appear/disappear
- [ ] Manual: delete an archived division, verify cascade removes groups/teams/games

🤖 Generated with [Claude Code](https://claude.com/claude-code)