### PR TITLE
Add archive/delete for groups

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
           npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0001_initial.sql
           npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0003_team_archived.sql || true
           npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0004_division_archived.sql || true
+          npx wrangler d1 execute ping-pong-club-db --remote --file=migrations/0005_group_archived.sql || true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.PING_PONG_CLUB_CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -67,6 +67,7 @@ app.get('/data', async (c) => {
     })),
     groups: groupsR.results.map(r => ({
       id: r.id, divisionId: r.division_id, number: r.number, teamIds: jsonParse(r.team_ids),
+      isArchived: bool(r.is_archived),
     })),
     players: playersR.results.map(r => ({
       id: r.id, firstName: r.first_name, lastName: r.last_name,
@@ -377,8 +378,8 @@ app.delete('/clubs/:clubId/addresses/:addressId', async (c) => {
 app.post('/groups', async (c) => {
   const d = await c.req.json()
   await c.env.DB.prepare(
-    'INSERT INTO groups_tbl (id, division_id, number, team_ids) VALUES (?, ?, ?, ?)'
-  ).bind(d.id, d.divisionId, d.number, jsonStr(d.teamIds ?? [])).run()
+    'INSERT INTO groups_tbl (id, division_id, number, team_ids, is_archived) VALUES (?, ?, ?, ?, ?)'
+  ).bind(d.id, d.divisionId, d.number, jsonStr(d.teamIds ?? []), d.isArchived ? 1 : 0).run()
   return c.json({ ok: true })
 })
 
@@ -389,7 +390,39 @@ app.patch('/groups/:id', async (c) => {
   if ('divisionId' in p) { s.push('division_id = ?'); v.push(p.divisionId) }
   if ('number' in p) { s.push('number = ?'); v.push(p.number) }
   if ('teamIds' in p) { s.push('team_ids = ?'); v.push(jsonStr(p.teamIds)) }
+  if ('isArchived' in p) { s.push('is_archived = ?'); v.push(p.isArchived ? 1 : 0) }
   if (s.length) { v.push(id); await c.env.DB.prepare(`UPDATE groups_tbl SET ${s.join(', ')} WHERE id = ?`).bind(...v).run() }
+  return c.json({ ok: true })
+})
+
+// Delete group (archived only) — cascades: teams, match days → games → availabilities → selections
+app.delete('/groups/:id', async (c) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  // Delete teams in this group (and their game cascades)
+  const teamsR = await db.prepare('SELECT id FROM teams WHERE group_id = ?').bind(id).all()
+  for (const t of teamsR.results) {
+    const tid = t.id as string
+    const gamesR = await db.prepare('SELECT id FROM games WHERE home_team_id = ? OR away_team_id = ?').bind(tid, tid).all()
+    for (const g of gamesR.results) {
+      await db.prepare('DELETE FROM game_availabilities WHERE game_id = ?').bind(g.id).run()
+      await db.prepare('DELETE FROM game_selections WHERE game_id = ?').bind(g.id).run()
+    }
+    await db.prepare('DELETE FROM games WHERE home_team_id = ? OR away_team_id = ?').bind(tid, tid).run()
+  }
+  await db.prepare('DELETE FROM teams WHERE group_id = ?').bind(id).run()
+  // Delete match days in this group and their games/availabilities/selections
+  const matchDaysR = await db.prepare('SELECT id FROM match_days WHERE group_id = ?').bind(id).all()
+  for (const md of matchDaysR.results) {
+    const mdGamesR = await db.prepare('SELECT id FROM games WHERE match_day_id = ?').bind(md.id).all()
+    for (const g of mdGamesR.results) {
+      await db.prepare('DELETE FROM game_availabilities WHERE game_id = ?').bind(g.id).run()
+      await db.prepare('DELETE FROM game_selections WHERE game_id = ?').bind(g.id).run()
+    }
+    await db.prepare('DELETE FROM games WHERE match_day_id = ?').bind(md.id).run()
+  }
+  await db.prepare('DELETE FROM match_days WHERE group_id = ?').bind(id).run()
+  await db.prepare('DELETE FROM groups_tbl WHERE id = ?').bind(id).run()
   return c.json({ ok: true })
 })
 

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -50,7 +50,8 @@ CREATE TABLE IF NOT EXISTS groups_tbl (
   id TEXT PRIMARY KEY,
   division_id TEXT NOT NULL,
   number INTEGER NOT NULL,
-  team_ids TEXT NOT NULL DEFAULT '[]'
+  team_ids TEXT NOT NULL DEFAULT '[]',
+  is_archived INTEGER NOT NULL DEFAULT 0
 );
 
 -- Players

--- a/migrations/0005_group_archived.sql
+++ b/migrations/0005_group_archived.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups_tbl ADD COLUMN is_archived INTEGER NOT NULL DEFAULT 0;

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -80,6 +80,8 @@ interface DataContextValue extends Omit<DataState, 'users'> {
   archivePhase: (id: string) => void
   deletePhase: (id: string) => void
   updateGroup: (id: string, patch: Partial<Group>) => void
+  archiveGroup: (id: string) => void
+  deleteGroup: (id: string) => void
   updateTeam: (id: string, patch: Partial<Team>) => void
   archiveTeam: (id: string) => void
   deleteTeam: (id: string) => void
@@ -421,6 +423,38 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
     return group
   }, [persist])
 
+  const archiveGroup = useCallback((id: string) => {
+    setGroups((prev) => prev.map((g) => (g.id === id ? { ...g, isArchived: true } : g)))
+    if (persist) api(`/groups/${id}`, { method: 'PATCH', body: JSON.stringify({ isArchived: true }) })
+  }, [persist])
+
+  const deleteGroup = useCallback((id: string) => {
+    // Cascade: remove teams in this group and their games/availabilities/selections
+    const groupTeamIds = teams.filter((t) => t.groupId === id).map((t) => t.id)
+    const groupMatchDayIds = matchDays.filter((md) => md.groupId === id).map((md) => md.id)
+    const affectedGameIds = games
+      .filter(
+        (g) =>
+          groupMatchDayIds.includes(g.matchDayId) ||
+          groupTeamIds.includes(g.homeTeamId) ||
+          groupTeamIds.includes(g.awayTeamId)
+      )
+      .map((g) => g.id)
+    if (affectedGameIds.length > 0) {
+      setGames((prev) => prev.filter((g) => !affectedGameIds.includes(g.id)))
+      setGameAvailabilities((prev) => prev.filter((a) => !affectedGameIds.includes(a.gameId)))
+      setGameSelections((prev) => prev.filter((s) => !affectedGameIds.includes(s.gameId)))
+    }
+    if (groupMatchDayIds.length > 0) {
+      setMatchDays((prev) => prev.filter((md) => !groupMatchDayIds.includes(md.id)))
+    }
+    if (groupTeamIds.length > 0) {
+      setTeams((prev) => prev.filter((t) => !groupTeamIds.includes(t.id)))
+    }
+    setGroups((prev) => prev.filter((g) => g.id !== id))
+    if (persist) api(`/groups/${id}`, { method: 'DELETE' })
+  }, [persist, teams, matchDays, games])
+
   // --- Teams ---
   const updateTeam = useCallback((id: string, patch: Partial<Team>) => {
     setTeams((prev) => {
@@ -694,6 +728,8 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       archivePhase,
       deletePhase,
       updateGroup,
+      archiveGroup,
+      deleteGroup,
       updateTeam,
       archiveTeam,
       deleteTeam,
@@ -724,7 +760,7 @@ export function DataProvider({ children, initialData }: DataProviderProps) {
       matchDays, games,
       updateDivision, archiveDivision, deleteDivision,
       updateClub, archiveClub, addClubAddress, updateClubAddress, deleteClubAddress,
-      updateSeason, archiveSeason, deleteSeason, updatePhase, archivePhase, deletePhase, updateGroup, updateTeam, archiveTeam, deleteTeam,
+      updateSeason, archiveSeason, deleteSeason, updatePhase, archivePhase, deletePhase, updateGroup, archiveGroup, deleteGroup, updateTeam, archiveTeam, deleteTeam,
       addClub, addSeason, addPhase, addDivision, addGroup, addTeam,
       moveDivisionUp, moveDivisionDown,
       updatePlayer, addPlayer,

--- a/src/mock/data.ts
+++ b/src/mock/data.ts
@@ -77,9 +77,9 @@ export const mockPlayers: Player[] = [
 ]
 
 export const mockGroups: Group[] = [
-  { id: 'group-1', divisionId: 'div-1', number: 1, teamIds: ['team-1', 'team-2', 'team-3', 'team-4', 'team-5', 'team-6', 'team-7', 'team-8'] },
-  { id: 'group-2', divisionId: 'div-2', number: 1, teamIds: ['team-9', 'team-10', 'team-11', 'team-12'] },
-  { id: 'group-3', divisionId: 'div-3', number: 1, teamIds: ['team-13', 'team-14', 'team-15', 'team-16', 'team-17', 'team-18', 'team-19', 'team-20'] },
+  { id: 'group-1', divisionId: 'div-1', number: 1, teamIds: ['team-1', 'team-2', 'team-3', 'team-4', 'team-5', 'team-6', 'team-7', 'team-8'], isArchived: false },
+  { id: 'group-2', divisionId: 'div-2', number: 1, teamIds: ['team-9', 'team-10', 'team-11', 'team-12'], isArchived: false },
+  { id: 'group-3', divisionId: 'div-3', number: 1, teamIds: ['team-13', 'team-14', 'team-15', 'team-16', 'team-17', 'team-18', 'team-19', 'team-20'], isArchived: false },
 ]
 
 export const mockTeams: Team[] = [

--- a/src/pages/admin/GroupsPage.tsx
+++ b/src/pages/admin/GroupsPage.tsx
@@ -1,12 +1,18 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { Group } from '@/types'
 import { useAppData } from '@/contexts/DataContext'
 
 export function GroupsPage() {
-  const { groups, divisions, phases, teams, clubs, updateGroup, addGroup } = useAppData()
+  const { groups: allGroups, divisions, phases, teams, clubs, updateGroup, addGroup, archiveGroup, deleteGroup } = useAppData()
   const [editing, setEditing] = useState<Group | null>(null)
   const [creating, setCreating] = useState(false)
   const [form, setForm] = useState({ divisionId: '', number: 1 })
+
+  const [showArchived, setShowArchived] = useState(false)
+
+  const activeGroups = useMemo(() => allGroups.filter((g) => !g.isArchived), [allGroups])
+  const archivedGroups = useMemo(() => allGroups.filter((g) => g.isArchived), [allGroups])
+  const groups = showArchived ? allGroups : activeGroups
 
   const getDivisionName = (divisionId: string) =>
     divisions.find((d) => d.id === divisionId)?.displayName ?? divisionId
@@ -32,7 +38,7 @@ export function GroupsPage() {
     setCreating(true)
     setForm({
       divisionId: divisions[0]?.id ?? '',
-      number: groups.filter((g) => g.divisionId === divisions[0]?.id).length + 1,
+      number: allGroups.filter((g) => g.divisionId === divisions[0]?.id).length + 1,
     })
   }
 
@@ -50,8 +56,21 @@ export function GroupsPage() {
         divisionId: form.divisionId,
         number: form.number,
         teamIds: [],
+        isArchived: false,
       })
       closeModal()
+    }
+  }
+
+  const handleArchive = (group: Group) => {
+    if (window.confirm(`Archiver le groupe "${getDivisionName(group.divisionId)} - Groupe ${group.number}" ? Il ne sera plus visible dans la liste active.`)) {
+      archiveGroup(group.id)
+    }
+  }
+
+  const handleDelete = (group: Group) => {
+    if (window.confirm(`Supprimer définitivement le groupe "${getDivisionName(group.divisionId)} - Groupe ${group.number}" ? Les équipes, journées, matchs, disponibilités et compositions associés seront également supprimés. Cette action est irréversible.`)) {
+      deleteGroup(group.id)
     }
   }
 
@@ -73,6 +92,19 @@ export function GroupsPage() {
           Ajouter un groupe
         </button>
       </div>
+      {archivedGroups.length > 0 && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="rounded border-slate-300"
+          />
+          <span className="text-sm text-slate-600">
+            Afficher les groupes archivés ({archivedGroups.length})
+          </span>
+        </label>
+      )}
       <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
         <table className="min-w-full divide-y divide-slate-200">
           <thead className="bg-slate-50">
@@ -96,9 +128,14 @@ export function GroupsPage() {
           </thead>
           <tbody className="divide-y divide-slate-200 bg-white">
             {groups.map((group) => (
-              <tr key={group.id} className="hover:bg-slate-50/50">
+              <tr key={group.id} className={`hover:bg-slate-50/50 ${group.isArchived ? 'opacity-50' : ''}`}>
                 <td className="px-4 py-3 text-sm font-medium text-slate-900">
                   {getDivisionName(group.divisionId)}
+                  {group.isArchived && (
+                    <span className="ml-2 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600">
+                      Archivé
+                    </span>
+                  )}
                 </td>
                 <td className="px-4 py-3 text-sm text-slate-600">
                   {getPhaseName(getPhaseIdForDivision(group.divisionId) ?? '')}
@@ -107,14 +144,34 @@ export function GroupsPage() {
                 <td className="px-4 py-3 text-sm text-slate-600">
                   {group.teamIds.map(getTeamLabel).join(', ') || '—'}
                 </td>
-                <td className="px-4 py-3 text-right">
-                  <button
-                    type="button"
-                    onClick={() => openEdit(group)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                  >
-                    Modifier
-                  </button>
+                <td className="px-4 py-3 text-right space-x-3">
+                  {!group.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => openEdit(group)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Modifier
+                    </button>
+                  )}
+                  {!group.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleArchive(group)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Archiver
+                    </button>
+                  )}
+                  {group.isArchived && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(group)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Supprimer
+                    </button>
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,7 @@ export interface Group {
   divisionId: string
   number: number
   teamIds: string[]
+  isArchived: boolean
 }
 
 export interface Player {


### PR DESCRIPTION
## Summary
- Add `isArchived` field to Group type, DB schema (migration 0005), and API
- Add `archiveGroup` / `deleteGroup` to DataContext with full cascade (teams, match days, games, availabilities, selections)
- Update GroupsPage with archive/delete UI following the same pattern as TeamsPage (toggle checkbox, archive button on active, delete button on archived, French confirmation dialogs)
- Update mock data and deploy workflow

Closes #33

## Test plan
- [x] `npm run build` passes (no TypeScript errors)
- [x] `npm run test:run` passes (all 31 tests green)
- [ ] Verify archive button shows on active groups, sets group as archived
- [ ] Verify archived groups appear with opacity-50 and "Archivé" badge
- [ ] Verify delete button on archived groups removes group and cascades to teams/games/availabilities/selections
- [ ] Verify deploy workflow runs migration 0005 on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)