### PR TITLE
Sort teams alphabetically on Journées page

### DIFF
--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -336,7 +336,13 @@ export function MatchDaysPage() {
     if (!selectedPhaseId || !user?.clubIds?.length) return []
     return teams
       .filter((t) => t.phaseId === selectedPhaseId && user!.clubIds!.includes(t.clubId))
-      .sort((a, b) => (a.groupId === b.groupId ? a.number - b.number : a.groupId.localeCompare(b.groupId)))
+      .sort((a, b) => {
+        const clubA = clubs.find((c) => c.id === a.clubId)?.displayName ?? a.clubId
+        const clubB = clubs.find((c) => c.id === b.clubId)?.displayName ?? b.clubId
+        const nameA = `${clubA} ${a.number}`
+        const nameB = `${clubB} ${b.number}`
+        return nameA.localeCompare(nameB)
+      })
   }, [teams, selectedPhaseId, user?.clubIds])
 
   /** Match-days for a given team (its group). */


### PR DESCRIPTION
## Summary
- Team sections on the Journées page are now sorted alphabetically by display name (e.g. "PPA Rixheim 1" before "PPA Rixheim 5")
- Previously sorted by groupId then number, which didn't guarantee alphabetical order

Closes #59

## Test plan
- [ ] Open Journées page — verify team sections appear in A-Z order

🤖 Generated with [Claude Code](https://claude.com/claude-code)