### PR TITLE
Add global match-day switcher and sticky header (#63)

### DIFF
--- a/src/pages/admin/MatchDaysPage.tsx
+++ b/src/pages/admin/MatchDaysPage.tsx
@@ -391,6 +391,19 @@ export function MatchDaysPage() {
   const [matchDayOffsetByTeamId, setMatchDayOffsetByTeamId] = useState<Record<string, number>>({})
   const [otherMatchDayOffset, setOtherMatchDayOffset] = useState(0)
 
+  const stickysentinelRef = useRef<HTMLDivElement>(null)
+  const [isStuck, setIsStuck] = useState(false)
+  useEffect(() => {
+    const el = stickysentinelRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { threshold: 0 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   /** Global match-day offset applied to all teams at once. */
   const [globalMatchDayOffset, setGlobalMatchDayOffset] = useState(0)
   const globalMaxMatchDays = useMemo(
@@ -662,8 +675,9 @@ export function MatchDaysPage() {
 
   return (
     <div className="space-y-6">
+      <div ref={stickysentinelRef} className="h-0" aria-hidden />
       <div className="sticky top-14 z-10 -mx-4 bg-slate-50 px-4 pb-1 pt-0 sm:-mx-6 sm:px-6">
-        <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+        <div className={`rounded-xl border border-slate-200 bg-white px-4 py-3 transition-shadow duration-200 ${isStuck ? 'shadow-md' : ''}`}>
         <div className="flex items-center justify-between gap-4">
           <h1 className="font-display text-lg font-semibold text-slate-800 shrink-0">
             Journées


### PR DESCRIPTION
## Summary
- **Sticky header**: page header (title, phase selector, team jump) now sticks to top when scrolling
- **Global match-day switcher**: prev/next arrows in the header sync all team tables and "Autres joueurs" to the same match-day window
- Per-team switchers are preserved for independent navigation

Closes #63

## Test plan
- [ ] Scroll down — header stays visible at top
- [ ] Use global arrows — all team tables switch match days in sync
- [ ] Use a per-team arrow — only that team changes
- [ ] Switch phase — global offset resets to 0
- [ ] Global switcher only appears when there are more than 3 match days

🤖 Generated with [Claude Code](https://claude.com/claude-code)