### PR TITLE
Redesign team edit modal (#71)

### DIFF
--- a/src/pages/admin/TeamsPage.tsx
+++ b/src/pages/admin/TeamsPage.tsx
@@ -368,7 +368,7 @@ export function TeamsPage() {
           aria-modal="true"
           aria-labelledby="team-modal-title"
         >
-          <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-lg my-8">
+          <div className="w-full max-w-3xl rounded-xl bg-white p-6 shadow-lg my-8">
             <h2 id="team-modal-title" className="font-display text-lg font-semibold text-slate-800">
               {creating ? 'Ajouter une équipe' : 'Modifier l\'équipe'}
             </h2>
@@ -506,21 +506,6 @@ export function TeamsPage() {
                 </div>
               </div>
 
-              {/* WhatsApp link */}
-              <div>
-                <label htmlFor="team-whatsapp" className="block text-sm font-medium text-slate-700">
-                  Groupe WhatsApp
-                </label>
-                <input
-                  id="team-whatsapp"
-                  type="url"
-                  value={form.whatsappLink}
-                  onChange={(e) => setForm((f) => ({ ...f, whatsappLink: e.target.value }))}
-                  placeholder="https://chat.whatsapp.com/..."
-                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-                />
-              </div>
-
               {/* Player table */}
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-2">
@@ -632,6 +617,21 @@ export function TeamsPage() {
                     </select>
                   </div>
                 )}
+              </div>
+
+              {/* WhatsApp link */}
+              <div>
+                <label htmlFor="team-whatsapp" className="block text-sm font-medium text-slate-700">
+                  Groupe WhatsApp
+                </label>
+                <input
+                  id="team-whatsapp"
+                  type="url"
+                  value={form.whatsappLink}
+                  onChange={(e) => setForm((f) => ({ ...f, whatsappLink: e.target.value }))}
+                  placeholder="https://chat.whatsapp.com/..."
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                />
               </div>
             </div>
             <div className="mt-6 flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- **Wider modal** (max-w-2xl) with better grid layout
- **Player table** with columns: Joueur, Licence, Points (phase), Capitaine, Actions
- **Captain radio buttons** in the table (replaces dropdown)
- **Player filter**: players already in another team in the same phase are excluded from "add player"
- **Day dropdown** (Lundi–Dimanche) replaces free text input
- **Time dropdown** with common times (14h00–21h00)
- **WhatsApp group link** field

Closes #71

## Test plan
- [ ] Edit a team: modal is wider, player table renders correctly
- [ ] Captain selection via radio works
- [ ] "Add player" dropdown excludes players in other teams of the same phase
- [ ] Day and time dropdowns work
- [ ] WhatsApp link saves and persists
- [ ] Create new team flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)