### PR TITLE
Allow login as any club player in mock auth (#73)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,8 +1,35 @@
 import { createContext, useCallback, useContext, useMemo, useState } from 'react'
 import type { User } from '@/types'
-import { mockUsers, getDisplayNameForUser, getRoleLabel } from '@/mock/data'
+import { mockUsers, mockPlayers, getDisplayNameForUser, getRoleLabel } from '@/mock/data'
 
 const STORAGE_KEY = 'ping-pong-club-dev-user-id'
+
+/**
+ * Build a User for any player not in mockUsers.
+ * Assigns 'player' role with their club access.
+ */
+function buildAdHocUser(playerId: string): User | null {
+  const player = mockPlayers.find((p) => p.id === playerId)
+  if (!player || !player.clubId) return null
+  return {
+    id: `adhoc-${playerId}`,
+    email: player.email,
+    role: 'player',
+    playerId: player.id,
+    clubIds: [player.clubId],
+    captainTeamIds: [],
+  }
+}
+
+/** All selectable users: explicit mock users + ad-hoc users for remaining players. */
+const allSelectableUsers: User[] = (() => {
+  const coveredPlayerIds = new Set(mockUsers.map((u) => u.playerId).filter(Boolean))
+  const adHoc = mockPlayers
+    .filter((p) => p.clubId && !coveredPlayerIds.has(p.id))
+    .map((p) => buildAdHocUser(p.id)!)
+    .filter(Boolean)
+  return [...mockUsers, ...adHoc]
+})()
 
 interface AuthContextValue {
   user: User | null
@@ -24,7 +51,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const user = useMemo(() => {
     if (!userId) return null
-    return mockUsers.find((u) => u.id === userId) ?? null
+    // Check explicit mock users first, then ad-hoc
+    return allSelectableUsers.find((u) => u.id === userId) ?? null
   }, [userId])
 
   const login = useCallback((id: string) => {
@@ -48,7 +76,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     login,
     logout,
     isAuthenticated: !!user,
-    mockUsers,
+    mockUsers: allSelectableUsers,
   }), [user, login, logout])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>


### PR DESCRIPTION
## Summary
- All PPA Rixheim players now appear in the login autocomplete
- Players without explicit mock user entries get ad-hoc `player` role accounts
- Existing mock users (admin, club admin, captains) keep their roles
- Enables simulating activity from any player until real auth (#13) is implemented

Closes #73

## Test plan
- [x] All tests pass
- [ ] Login page shows all ~45 players in autocomplete
- [ ] Typing a name filters correctly
- [ ] Logging in as an ad-hoc player shows correct club data

🤖 Generated with [Claude Code](https://claude.com/claude-code)