### PR TITLE
Show club name instead of role in header (#78)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
+import { useAppData } from '@/contexts/DataContext'
 
 const prNumber = __PR_NUMBER__
 const commitSha = __COMMIT_SHA__
@@ -21,8 +22,12 @@ export function AppShell() {
   const { user, displayName, roleLabel, logout } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
+  const { clubs } = useAppData()
   const isGeneralAdmin = user?.role === 'general_admin'
   const isClubAdmin = user?.role === 'club_admin'
+  const clubLabel = !isGeneralAdmin && user?.clubIds?.length
+    ? clubs.filter((c) => user.clubIds.includes(c.id)).map((c) => c.displayName).join(', ')
+    : null
 
   const handleLogout = () => {
     if (window.confirm('Se déconnecter ?')) {
@@ -94,7 +99,7 @@ export function AppShell() {
             <div className="flex items-center gap-2 border-l border-slate-200 pl-4">
               <div className="hidden sm:block text-right">
                 <p className="text-sm font-medium text-slate-800">{displayName}</p>
-                <p className="text-xs text-slate-500">{roleLabel}</p>
+                <p className="text-xs text-slate-500">{clubLabel || roleLabel}</p>
               </div>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- Show club name (e.g. "PPA Rixheim") under user name for club members
- General admin still sees "Administrateur général"

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)